### PR TITLE
feat(runtime-core): add minimal engine loop

### DIFF
--- a/packages/runtime-core/src/AppLoop.js
+++ b/packages/runtime-core/src/AppLoop.js
@@ -1,0 +1,63 @@
+export class AppLoop {
+  constructor(callback) {
+    this.callback = callback;
+    this._running = false;
+    this._id = null;
+    this._lastTime = 0;
+
+    this._boundLoop = this._loop.bind(this);
+    this._visibilityHandler = this._handleVisibilityChange.bind(this);
+  }
+
+  start() {
+    if (this._running) return;
+    this._running = true;
+    this._lastTime = typeof performance !== 'undefined' ? performance.now() : 0;
+    this._id = requestAnimationFrame(this._boundLoop);
+
+    if (typeof document !== 'undefined' && document.addEventListener) {
+      document.addEventListener('visibilitychange', this._visibilityHandler);
+    }
+  }
+
+  stop() {
+    if (!this._running) return;
+    this._running = false;
+    if (this._id != null) {
+      cancelAnimationFrame(this._id);
+      this._id = null;
+    }
+
+    if (typeof document !== 'undefined' && document.removeEventListener) {
+      document.removeEventListener('visibilitychange', this._visibilityHandler);
+    }
+  }
+
+  _handleVisibilityChange() {
+    if (!this._running || typeof document === 'undefined') return;
+
+    if (document.visibilityState === 'hidden') {
+      if (this._id != null) {
+        cancelAnimationFrame(this._id);
+        this._id = null;
+      }
+    } else {
+      this._lastTime = typeof performance !== 'undefined' ? performance.now() : 0;
+      this._id = requestAnimationFrame(this._boundLoop);
+    }
+  }
+
+  _loop(time) {
+    if (!this._running) return;
+
+    const dt = time - this._lastTime;
+    this._lastTime = time;
+    this.callback(dt, time);
+
+    if (this._running) {
+      this._id = requestAnimationFrame(this._boundLoop);
+    }
+  }
+}
+
+export default AppLoop;

--- a/packages/runtime-core/src/Engine.js
+++ b/packages/runtime-core/src/Engine.js
@@ -1,0 +1,31 @@
+import { AppLoop } from './AppLoop.js';
+
+export class Engine {
+  constructor() {
+    this.subsystems = [];
+    this._loop = new AppLoop(this._update.bind(this));
+  }
+
+  add(subsystem) {
+    this.subsystems.push(subsystem);
+    return subsystem;
+  }
+
+  start() {
+    this._loop.start();
+  }
+
+  stop() {
+    this._loop.stop();
+  }
+
+  _update(dt, time) {
+    for (const system of this.subsystems) {
+      if (system && typeof system.update === 'function') {
+        system.update(dt, time);
+      }
+    }
+  }
+}
+
+export default Engine;

--- a/packages/runtime-core/test/Engine.test.mjs
+++ b/packages/runtime-core/test/Engine.test.mjs
@@ -1,0 +1,44 @@
+import test from 'ava';
+import { Engine } from '../src/Engine.js';
+
+test('engine calls subsystems in order with positive dt', async t => {
+  let current = typeof performance !== 'undefined' ? performance.now() : 0;
+  globalThis.requestAnimationFrame = cb => setTimeout(() => { current += 16; cb(current); }, 0);
+  globalThis.cancelAnimationFrame = id => clearTimeout(id);
+
+  const engine = new Engine();
+  const order = [];
+  const dts = [];
+
+  await new Promise(resolve => {
+    let frames = 0;
+
+    engine.add({
+      update(dt) {
+        order.push('a');
+        dts.push(dt);
+        frames += 1;
+        if (frames >= 3) {
+          engine.stop();
+          resolve();
+        }
+      }
+    });
+
+    engine.add({
+      update(dt) {
+        order.push('b');
+        dts.push(dt);
+      }
+    });
+
+    engine.start();
+  });
+
+  t.true(order.length >= 6);
+  for (let i = 0; i < order.length; i += 2) {
+    t.is(order[i], 'a');
+    t.is(order[i + 1], 'b');
+  }
+  dts.forEach(dt => t.true(dt > 0));
+});


### PR DESCRIPTION
## Summary
- implement `Engine` with subsystem management and start/stop control
- add `AppLoop` to centralize rAF timing and visibility handling
- add AVA test ensuring subsystems update in order and receive positive dt

## Testing
- `npx ava packages/runtime-core/test/Engine.test.mjs` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ava)*
- `node packages/runtime-core/test/Engine.test.mjs` *(fails: Cannot find package 'ava')*


------
https://chatgpt.com/codex/tasks/task_e_68ba495168d8832cae0d30c200898d11