### PR TITLE
feat(editor): add editor app shell and panels

### DIFF
--- a/examples/editor/index.html
+++ b/examples/editor/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Axis Forge Editor</title>
+    <style>
+      html,body { height:100%; margin:0; }
+    </style>
+    <script type="module">
+      import AppShell from '/packages/editor/src/AppShell.js';
+      new AppShell(document.body);
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/packages/editor/src/AppShell.js
+++ b/packages/editor/src/AppShell.js
@@ -1,0 +1,176 @@
+import ExplorerPanel from './Panels/ExplorerPanel.js';
+import PropertiesPanel from './Panels/PropertiesPanel.js';
+import ViewportPanel from './Panels/ViewportPanel.js';
+import ConsolePanel from './Panels/ConsolePanel.js';
+
+/**
+ * Editor application shell. Creates the primary dockable layout consisting of
+ * Explorer, Properties, Viewport and Console panels. Panel sizes are
+ * persistent via localStorage so the layout restores when the editor is
+ * reloaded.
+ */
+export default class AppShell {
+  constructor(container = document.body) {
+    this.container = container;
+    this.layoutKey = 'editor-layout';
+
+    const saved = this.#loadLayout();
+    this.leftWidth = saved.leftWidth ?? 200;
+    this.rightWidth = saved.rightWidth ?? 250;
+    this.bottomHeight = saved.bottomHeight ?? 150;
+
+    this.#build();
+    this.#saveLayout();
+  }
+
+  /** Build DOM structure */
+  #build() {
+    this.root = document.createElement('div');
+    this.root.id = 'editor-app';
+    this.root.style.display = 'flex';
+    this.root.style.height = '100vh';
+    this.container.appendChild(this.root);
+
+    // Explorer
+    this.explorerEl = document.createElement('div');
+    this.explorerEl.id = 'explorer';
+    this.explorerEl.style.width = this.leftWidth + 'px';
+    this.explorerEl.style.overflow = 'auto';
+    this.root.appendChild(this.explorerEl);
+
+    // Left resizer
+    this.leftResizer = document.createElement('div');
+    this.leftResizer.className = 'v-resizer';
+    this.root.appendChild(this.leftResizer);
+
+    // Center container (viewport + console)
+    this.center = document.createElement('div');
+    this.center.style.flex = '1';
+    this.center.style.display = 'flex';
+    this.center.style.flexDirection = 'column';
+    this.root.appendChild(this.center);
+
+    // Viewport panel
+    this.viewportEl = document.createElement('div');
+    this.viewportEl.id = 'viewport';
+    this.viewportEl.style.flex = '1';
+    this.viewportEl.style.overflow = 'hidden';
+    this.center.appendChild(this.viewportEl);
+
+    // Horizontal resizer
+    this.bottomResizer = document.createElement('div');
+    this.bottomResizer.className = 'h-resizer';
+    this.center.appendChild(this.bottomResizer);
+
+    // Console panel
+    this.consoleEl = document.createElement('div');
+    this.consoleEl.id = 'console';
+    this.consoleEl.style.height = this.bottomHeight + 'px';
+    this.consoleEl.style.overflow = 'auto';
+    this.center.appendChild(this.consoleEl);
+
+    // Right resizer
+    this.rightResizer = document.createElement('div');
+    this.rightResizer.className = 'v-resizer';
+    this.root.appendChild(this.rightResizer);
+
+    // Properties
+    this.propertiesEl = document.createElement('div');
+    this.propertiesEl.id = 'properties';
+    this.propertiesEl.style.width = this.rightWidth + 'px';
+    this.propertiesEl.style.overflow = 'auto';
+    this.root.appendChild(this.propertiesEl);
+
+    // Panels
+    const instances = ExplorerPanel.createDefaultInstances();
+    this.explorer = new ExplorerPanel(this.explorerEl, instances);
+    this.properties = new PropertiesPanel(this.propertiesEl);
+    this.viewport = new ViewportPanel(this.viewportEl);
+    this.console = new ConsolePanel(this.consoleEl);
+
+    // Selection hookup
+    this.explorer.onSelect(instance => {
+      this.properties.setInstance(instance);
+    });
+
+    // Resizers
+    this.#setupResizers();
+  }
+
+  /** Configure mouse-driven resizers */
+  #setupResizers() {
+    // Left vertical resizer
+    this.#drag(this.leftResizer, 'col', dx => {
+      this.leftWidth = Math.max(100, this.leftWidth + dx);
+      this.explorerEl.style.width = this.leftWidth + 'px';
+      this.#saveLayout();
+    });
+
+    // Right vertical resizer
+    this.#drag(this.rightResizer, 'col', dx => {
+      this.rightWidth = Math.max(100, this.rightWidth - dx);
+      this.propertiesEl.style.width = this.rightWidth + 'px';
+      this.#saveLayout();
+    });
+
+    // Bottom horizontal resizer
+    this.#drag(this.bottomResizer, 'row', dy => {
+      this.bottomHeight = Math.max(80, this.bottomHeight - dy);
+      this.consoleEl.style.height = this.bottomHeight + 'px';
+      this.#saveLayout();
+    });
+  }
+
+  /** Utility to handle dragging of resizer elements */
+  #drag(el, dir, onMove) {
+    el.addEventListener('mousedown', e => {
+      e.preventDefault();
+      const startX = e.clientX;
+      const startY = e.clientY;
+      const move = ev => {
+        const dx = ev.clientX - startX;
+        const dy = ev.clientY - startY;
+        onMove(dir === 'col' ? dx : dy);
+      };
+      const up = () => {
+        window.removeEventListener('mousemove', move);
+        window.removeEventListener('mouseup', up);
+      };
+      window.addEventListener('mousemove', move);
+      window.addEventListener('mouseup', up);
+    });
+  }
+
+  #loadLayout() {
+    try {
+      const raw = localStorage.getItem(this.layoutKey);
+      return raw ? JSON.parse(raw) : {};
+    } catch {
+      return {};
+    }
+  }
+
+  #saveLayout() {
+    const data = {
+      leftWidth: this.leftWidth,
+      rightWidth: this.rightWidth,
+      bottomHeight: this.bottomHeight
+    };
+    try {
+      localStorage.setItem(this.layoutKey, JSON.stringify(data));
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+// basic styles for resizers
+const style = document.createElement('style');
+style.textContent = `
+#editor-app { font-family: sans-serif; }
+.v-resizer { width: 5px; cursor: col-resize; background: #ddd; }
+.h-resizer { height: 5px; cursor: row-resize; background: #ddd; }
+.panel-title { font-weight: bold; padding: 4px; border-bottom: 1px solid #ccc; }
+.panel-body { padding: 4px; }
+`;
+document.head.appendChild(style);

--- a/packages/editor/src/Panels/ConsolePanel.js
+++ b/packages/editor/src/Panels/ConsolePanel.js
@@ -1,0 +1,36 @@
+/**
+ * Simple console panel capturing messages written to `console.log`. In the
+ * MVP it only displays logged text lines.
+ */
+export default class ConsolePanel {
+  constructor(container) {
+    this.container = container;
+    this.render();
+    this.#hookConsole();
+  }
+
+  render() {
+    this.container.innerHTML = '';
+    const title = document.createElement('div');
+    title.textContent = 'Console';
+    title.className = 'panel-title';
+    this.container.appendChild(title);
+
+    this.body = document.createElement('div');
+    this.body.className = 'panel-body';
+    this.body.style.height = '100%';
+    this.body.style.overflow = 'auto';
+    this.container.appendChild(this.body);
+  }
+
+  #hookConsole() {
+    const original = console.log;
+    console.log = (...args) => {
+      original.apply(console, args);
+      const line = document.createElement('div');
+      line.textContent = args.join(' ');
+      this.body.appendChild(line);
+      this.body.scrollTop = this.body.scrollHeight;
+    };
+  }
+}

--- a/packages/editor/src/Panels/ExplorerPanel.js
+++ b/packages/editor/src/Panels/ExplorerPanel.js
@@ -1,0 +1,69 @@
+/**
+ * Explorer panel displays a simple tree of instances. Instances are basic
+ * observable objects with a name and property bag. The panel emits a `select`
+ * callback when an instance is clicked.
+ */
+export default class ExplorerPanel {
+  constructor(container, instances = []) {
+    this.container = container;
+    this.instances = instances;
+    this.selectHandlers = [];
+    this.render();
+  }
+
+  static createDefaultInstances() {
+    return [
+      new Instance('Workspace'),
+      new Instance('ServerScripts'),
+      new Instance('ClientScripts'),
+      new Instance('SharedStorage')
+    ];
+  }
+
+  onSelect(fn) {
+    this.selectHandlers.push(fn);
+  }
+
+  render() {
+    this.container.innerHTML = '';
+    const title = document.createElement('div');
+    title.textContent = 'Explorer';
+    title.className = 'panel-title';
+    this.container.appendChild(title);
+
+    const body = document.createElement('div');
+    body.className = 'panel-body';
+    const ul = document.createElement('ul');
+    ul.style.listStyle = 'none';
+    ul.style.padding = '0';
+
+    for (const inst of this.instances) {
+      const li = document.createElement('li');
+      li.textContent = inst.properties.Name;
+      li.style.padding = '2px 4px';
+      li.style.cursor = 'pointer';
+      li.addEventListener('click', () => {
+        this.selectHandlers.forEach(h => h(inst));
+      });
+      inst.addEventListener('change', e => {
+        if (e.detail.key === 'Name') li.textContent = e.detail.value;
+      });
+      ul.appendChild(li);
+    }
+    body.appendChild(ul);
+    this.container.appendChild(body);
+  }
+}
+
+/** Simple observable instance used by the editor panels */
+export class Instance extends EventTarget {
+  constructor(name, props = {}) {
+    super();
+    this.properties = { Name: name, ...props };
+  }
+
+  setProperty(key, value) {
+    this.properties[key] = value;
+    this.dispatchEvent(new CustomEvent('change', { detail: { key, value } }));
+  }
+}

--- a/packages/editor/src/Panels/PropertiesPanel.js
+++ b/packages/editor/src/Panels/PropertiesPanel.js
@@ -1,0 +1,60 @@
+/**
+ * Properties panel lists properties of the selected instance and allows live
+ * editing. Updates propagate back to the instance through the Instance API.
+ */
+export default class PropertiesPanel {
+  constructor(container) {
+    this.container = container;
+    this.instance = null;
+    this.render();
+  }
+
+  setInstance(inst) {
+    this.instance = inst;
+    this.render();
+  }
+
+  render() {
+    this.container.innerHTML = '';
+    const title = document.createElement('div');
+    title.textContent = 'Properties';
+    title.className = 'panel-title';
+    this.container.appendChild(title);
+
+    const body = document.createElement('div');
+    body.className = 'panel-body';
+    if (!this.instance) {
+      body.textContent = 'No selection';
+      this.container.appendChild(body);
+      return;
+    }
+
+    for (const [key, value] of Object.entries(this.instance.properties)) {
+      const row = document.createElement('div');
+      row.style.display = 'flex';
+      row.style.marginBottom = '4px';
+
+      const label = document.createElement('label');
+      label.textContent = key;
+      label.style.width = '80px';
+      row.appendChild(label);
+
+      const input = document.createElement('input');
+      input.value = value;
+      input.style.flex = '1';
+      input.addEventListener('input', () => {
+        this.instance.setProperty(key, input.value);
+      });
+      // Live binding - update if instance property changes elsewhere
+      this.instance.addEventListener('change', e => {
+        if (e.detail.key === key && document.activeElement !== input) {
+          input.value = e.detail.value;
+        }
+      });
+      row.appendChild(input);
+      body.appendChild(row);
+    }
+
+    this.container.appendChild(body);
+  }
+}

--- a/packages/editor/src/Panels/ViewportPanel.js
+++ b/packages/editor/src/Panels/ViewportPanel.js
@@ -1,0 +1,29 @@
+/**
+ * Placeholder viewport panel. In the MVP it simply displays a coloured area
+ * but can later host a WebGPU canvas for scene rendering.
+ */
+export default class ViewportPanel {
+  constructor(container) {
+    this.container = container;
+    this.render();
+  }
+
+  render() {
+    this.container.innerHTML = '';
+    const title = document.createElement('div');
+    title.textContent = 'Viewport';
+    title.className = 'panel-title';
+    this.container.appendChild(title);
+
+    const body = document.createElement('div');
+    body.className = 'panel-body';
+    body.textContent = 'Scene view';
+    body.style.height = '100%';
+    body.style.background = '#222';
+    body.style.color = '#fff';
+    body.style.display = 'flex';
+    body.style.alignItems = 'center';
+    body.style.justifyContent = 'center';
+    this.container.appendChild(body);
+  }
+}

--- a/packages/editor/test/editor.spec.js
+++ b/packages/editor/test/editor.spec.js
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+
+test('panels are present', async ({ page }) => {
+  await page.goto('/editor/');
+  await expect(page.locator('#explorer')).toBeVisible();
+  await expect(page.locator('#properties')).toBeVisible();
+  await expect(page.locator('#viewport')).toBeVisible();
+  await expect(page.locator('#console')).toBeVisible();
+});
+
+test('layout reloads from localStorage', async ({ page }) => {
+  await page.goto('/editor/');
+  await page.evaluate(() => {
+    localStorage.setItem('editor-layout', JSON.stringify({
+      leftWidth: 210,
+      rightWidth: 190,
+      bottomHeight: 120
+    }));
+  });
+  await page.reload();
+  const leftWidth = await page.evaluate(() => document.getElementById('explorer').style.width);
+  const rightWidth = await page.evaluate(() => document.getElementById('properties').style.width);
+  const bottomHeight = await page.evaluate(() => document.getElementById('console').style.height);
+  expect(leftWidth).toBe('210px');
+  expect(rightWidth).toBe('190px');
+  expect(bottomHeight).toBe('120px');
+});

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,16 @@
+// Playwright configuration for editor tests
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './packages/editor/test',
+  webServer: {
+    command: 'node scripts/dev-server.mjs',
+    url: 'http://localhost:5173/editor/',
+    reuseExistingServer: !process.env.CI,
+    stdout: 'ignore',
+    stderr: 'pipe'
+  },
+  use: {
+    baseURL: 'http://localhost:5173'
+  }
+});


### PR DESCRIPTION
## Summary
- implement app shell with dockable Explorer, Viewport, Console, and Properties panels
- wire explorer selection to live-updating properties view
- add editor example page and Playwright tests with layout persistence

## Testing
- `npm test` *(fails: command not found)*
- `npx playwright test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baa98d61fc832c9d5f5cc4c94fd87a