### PR TITLE
feat(ui): add Roblox-style layout engine and primitives

### DIFF
--- a/packages/ui/src/LayoutEngine.js
+++ b/packages/ui/src/LayoutEngine.js
@@ -1,0 +1,54 @@
+import { UISizeConstraint } from './components/UISizeConstraint.js';
+
+export class LayoutEngine {
+  constructor(root) {
+    this.root = root;
+    this.frames = [];
+    if (this.root) {
+      this.root.style.position = 'relative';
+    }
+  }
+
+  add(frame, parent = null) {
+    const container = parent ? parent.element : this.root;
+    if (!container) throw new Error('No root element provided');
+    container.appendChild(frame.element);
+    (parent ? parent.children : this.frames).push(frame);
+  }
+
+  update() {
+    const rootWidth = this.root.clientWidth;
+    const rootHeight = this.root.clientHeight;
+
+    const layout = (frame, pw, ph) => {
+      let { x, y } = frame.position.resolve(pw, ph);
+      let { x: w, y: h } = frame.size.resolve(pw, ph);
+
+      for (const comp of frame.components) {
+        if (comp instanceof UISizeConstraint) {
+          const constrained = comp.apply(w, h);
+          w = constrained.width;
+          h = constrained.height;
+        }
+      }
+
+      const ax = frame.anchorPoint.x || 0;
+      const ay = frame.anchorPoint.y || 0;
+      frame.element.style.position = 'absolute';
+      frame.element.style.left = `${x - ax * w}px`;
+      frame.element.style.top = `${y - ay * h}px`;
+      frame.element.style.width = `${w}px`;
+      frame.element.style.height = `${h}px`;
+
+      for (const child of frame.children) {
+        layout(child, w, h);
+      }
+    };
+
+    for (const frame of this.frames) {
+      layout(frame, rootWidth, rootHeight);
+    }
+  }
+}
+
+export default LayoutEngine;

--- a/packages/ui/src/UDim.js
+++ b/packages/ui/src/UDim.js
@@ -1,0 +1,28 @@
+export class UDim {
+  constructor(scale = 0, offset = 0) {
+    this.scale = scale;
+    this.offset = offset;
+  }
+
+  add(other) {
+    return new UDim(this.scale + other.scale, this.offset + other.offset);
+  }
+
+  sub(other) {
+    return new UDim(this.scale - other.scale, this.offset - other.offset);
+  }
+
+  mul(value) {
+    return new UDim(this.scale * value, this.offset * value);
+  }
+
+  div(value) {
+    return new UDim(this.scale / value, this.offset / value);
+  }
+
+  resolve(container) {
+    return this.scale * container + this.offset;
+  }
+}
+
+export default UDim;

--- a/packages/ui/src/UDim2.js
+++ b/packages/ui/src/UDim2.js
@@ -1,0 +1,44 @@
+import { UDim } from './UDim.js';
+
+export class UDim2 {
+  constructor(scaleX = 0, offsetX = 0, scaleY = 0, offsetY = 0) {
+    if (scaleX instanceof UDim) {
+      this.x = scaleX;
+      this.y = offsetX instanceof UDim ? offsetX : new UDim();
+    } else {
+      this.x = new UDim(scaleX, offsetX);
+      this.y = new UDim(scaleY, offsetY);
+    }
+  }
+
+  add(other) {
+    return new UDim2(
+      this.x.add(other.x),
+      this.y.add(other.y)
+    );
+  }
+
+  sub(other) {
+    return new UDim2(
+      this.x.sub(other.x),
+      this.y.sub(other.y)
+    );
+  }
+
+  mul(value) {
+    return new UDim2(this.x.mul(value), this.y.mul(value));
+  }
+
+  div(value) {
+    return new UDim2(this.x.div(value), this.y.div(value));
+  }
+
+  resolve(width, height) {
+    return {
+      x: this.x.resolve(width),
+      y: this.y.resolve(height)
+    };
+  }
+}
+
+export default UDim2;

--- a/packages/ui/src/components/Frame.js
+++ b/packages/ui/src/components/Frame.js
@@ -1,0 +1,29 @@
+import { UDim2 } from '../UDim2.js';
+
+export class Frame {
+  constructor() {
+    this.size = new UDim2();
+    this.position = new UDim2();
+    this.anchorPoint = { x: 0, y: 0 };
+    this.element = document.createElement('div');
+    this.element.style.position = 'absolute';
+    this.children = [];
+    this.components = [];
+  }
+
+  addChild(child) {
+    this.children.push(child);
+    this.element.appendChild(child.element);
+    return child;
+  }
+
+  addComponent(component) {
+    this.components.push(component);
+    if (typeof component.apply === 'function') {
+      component.apply(this);
+    }
+    return component;
+  }
+}
+
+export default Frame;

--- a/packages/ui/src/components/UICorner.js
+++ b/packages/ui/src/components/UICorner.js
@@ -1,0 +1,11 @@
+export class UICorner {
+  constructor(radius = 0) {
+    this.radius = radius;
+  }
+
+  apply(frame) {
+    frame.element.style.borderRadius = `${this.radius}px`;
+  }
+}
+
+export default UICorner;

--- a/packages/ui/src/components/UISizeConstraint.js
+++ b/packages/ui/src/components/UISizeConstraint.js
@@ -1,0 +1,17 @@
+export class UISizeConstraint {
+  constructor({ minX = 0, minY = 0, maxX = Infinity, maxY = Infinity } = {}) {
+    this.minX = minX;
+    this.minY = minY;
+    this.maxX = maxX;
+    this.maxY = maxY;
+  }
+
+  apply(width, height) {
+    return {
+      width: Math.max(this.minX, Math.min(width, this.maxX)),
+      height: Math.max(this.minY, Math.min(height, this.maxY))
+    };
+  }
+}
+
+export default UISizeConstraint;

--- a/packages/ui/src/components/UIStroke.js
+++ b/packages/ui/src/components/UIStroke.js
@@ -1,0 +1,13 @@
+export class UIStroke {
+  constructor(color = 'black', thickness = 1) {
+    this.color = color;
+    this.thickness = thickness;
+  }
+
+  apply(frame) {
+    frame.element.style.boxSizing = 'border-box';
+    frame.element.style.border = `${this.thickness}px solid ${this.color}`;
+  }
+}
+
+export default UIStroke;

--- a/packages/ui/test/Layout.test.js
+++ b/packages/ui/test/Layout.test.js
@@ -1,0 +1,40 @@
+import test from 'ava';
+import { chromium } from 'playwright';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const toFileUrl = p => pathToFileURL(path.resolve(p)).href;
+
+test('layout engine positions frame', async t => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+
+  const frameURL = toFileUrl('packages/ui/src/components/Frame.js');
+  const udim2URL = toFileUrl('packages/ui/src/UDim2.js');
+  const layoutURL = toFileUrl('packages/ui/src/LayoutEngine.js');
+
+  const result = await page.evaluate(async ({ frameURL, udim2URL, layoutURL }) => {
+    const { Frame } = await import(frameURL);
+    const { UDim2 } = await import(udim2URL);
+    const { LayoutEngine } = await import(layoutURL);
+
+    document.body.style.margin = '0';
+    const root = document.createElement('div');
+    root.style.position = 'relative';
+    root.style.width = '200px';
+    root.style.height = '200px';
+    document.body.appendChild(root);
+
+    const engine = new LayoutEngine(root);
+    const frame = new Frame();
+    frame.size = new UDim2(0.5, 10, 0.5, 20);
+    frame.position = new UDim2(0.25, 5, 0.25, 10);
+    engine.add(frame);
+    engine.update();
+    const rect = frame.element.getBoundingClientRect();
+    return { x: Math.round(rect.x), y: Math.round(rect.y), width: Math.round(rect.width), height: Math.round(rect.height) };
+  }, { frameURL, udim2URL, layoutURL });
+
+  await browser.close();
+  t.deepEqual(result, { x: 55, y: 60, width: 110, height: 120 });
+});

--- a/packages/ui/test/UDim.test.js
+++ b/packages/ui/test/UDim.test.js
@@ -1,0 +1,22 @@
+import test from 'ava';
+import { UDim } from '../src/UDim.js';
+import { UDim2 } from '../src/UDim2.js';
+
+test('UDim arithmetic and resolve', t => {
+  const u1 = new UDim(0.5, 10);
+  const u2 = new UDim(0.25, 5);
+  const u3 = u1.add(u2);
+  t.is(u3.scale, 0.75);
+  t.is(u3.offset, 15);
+  t.is(u3.resolve(100), 90);
+});
+
+test('UDim2 arithmetic and resolve', t => {
+  const u1 = new UDim2(0.5, 10, 0.5, 20);
+  const u2 = new UDim2(0.25, 5, 0.25, 5);
+  const u3 = u1.add(u2);
+  t.is(u3.x.scale, 0.75);
+  t.is(u3.y.offset, 25);
+  const resolved = u3.resolve(200, 100);
+  t.deepEqual(resolved, { x: 0.75 * 200 + 15, y: 0.75 * 100 + 25 });
+});


### PR DESCRIPTION
## Summary
- add UDim and UDim2 numeric types
- implement Frame component with stroke, corner, size constraint support
- create layout engine that positions frames using Roblox-style scale/offset
- add AVA unit tests and Playwright layout example

## Testing
- `npm run lint`
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*
- `npx playwright install` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68baa9aa6684832caf08803d1db475e6