### PR TITLE
feat(editor): add basic transform gizmos

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,7 @@
     "typedoc": "^0.26.6",
     "@babel/parser": "^7.28.3"
   },
-  "dependencies": {}
+  "dependencies": {
+    "three": "^0.165.0"
+  }
 }

--- a/packages/editor/src/AppShell.js
+++ b/packages/editor/src/AppShell.js
@@ -2,6 +2,7 @@ import ExplorerPanel from './Panels/ExplorerPanel.js';
 import PropertiesPanel from './Panels/PropertiesPanel.js';
 import ViewportPanel from './Panels/ViewportPanel.js';
 import ConsolePanel from './Panels/ConsolePanel.js';
+import store from './EditorStore.js';
 
 /**
  * Editor application shell. Creates the primary dockable layout consisting of
@@ -85,12 +86,16 @@ export default class AppShell {
     const instances = ExplorerPanel.createDefaultInstances();
     this.explorer = new ExplorerPanel(this.explorerEl, instances);
     this.properties = new PropertiesPanel(this.propertiesEl);
-    this.viewport = new ViewportPanel(this.viewportEl);
+    this.viewport = new ViewportPanel(this.viewportEl, instances);
     this.console = new ConsolePanel(this.consoleEl);
 
-    // Selection hookup
+    // Selection hookup via store
     this.explorer.onSelect(instance => {
-      this.properties.setInstance(instance);
+      store.setSelection(instance);
+    });
+    store.addEventListener('selection', e => {
+      this.properties.setInstance(e.detail);
+      this.viewport.setInstance(e.detail);
     });
 
     // Resizers

--- a/packages/editor/src/EditorStore.js
+++ b/packages/editor/src/EditorStore.js
@@ -1,0 +1,27 @@
+class EditorStore extends EventTarget {
+  constructor() {
+    super();
+    this.state = {
+      selection: null,
+      space: 'world',
+      snap: 1
+    };
+  }
+
+  setSelection(inst) {
+    this.state.selection = inst;
+    this.dispatchEvent(new CustomEvent('selection', { detail: inst }));
+  }
+
+  setSpace(space) {
+    this.state.space = space;
+    this.dispatchEvent(new CustomEvent('space', { detail: space }));
+  }
+
+  setSnap(snap) {
+    this.state.snap = snap;
+    this.dispatchEvent(new CustomEvent('snap', { detail: snap }));
+  }
+}
+
+export default new EditorStore();

--- a/packages/editor/src/Panels/ExplorerPanel.js
+++ b/packages/editor/src/Panels/ExplorerPanel.js
@@ -14,6 +14,7 @@ export default class ExplorerPanel {
   static createDefaultInstances() {
     return [
       new Instance('Workspace'),
+      new Instance('Cube', { CFrame: '0,0,0' }),
       new Instance('ServerScripts'),
       new Instance('ClientScripts'),
       new Instance('SharedStorage')

--- a/packages/editor/src/Panels/PropertiesPanel.js
+++ b/packages/editor/src/Panels/PropertiesPanel.js
@@ -41,6 +41,7 @@ export default class PropertiesPanel {
 
       const input = document.createElement('input');
       input.value = value;
+      input.name = key;
       input.style.flex = '1';
       input.addEventListener('input', () => {
         this.instance.setProperty(key, input.value);

--- a/packages/editor/src/Panels/ViewportPanel.js
+++ b/packages/editor/src/Panels/ViewportPanel.js
@@ -1,14 +1,16 @@
-/**
- * Placeholder viewport panel. In the MVP it simply displays a coloured area
- * but can later host a WebGPU canvas for scene rendering.
- */
+import * as THREE from 'three';
+import { TransformControls } from 'three/examples/jsm/controls/TransformControls.js';
+import store from '../EditorStore.js';
+
 export default class ViewportPanel {
-  constructor(container) {
+  constructor(container, instances = []) {
     this.container = container;
-    this.render();
+    this.instances = instances;
+    this.objectMap = new Map();
+    this.#build();
   }
 
-  render() {
+  #build() {
     this.container.innerHTML = '';
     const title = document.createElement('div');
     title.textContent = 'Viewport';
@@ -17,13 +19,108 @@ export default class ViewportPanel {
 
     const body = document.createElement('div');
     body.className = 'panel-body';
-    body.textContent = 'Scene view';
+    body.style.position = 'relative';
+    body.style.padding = '0';
     body.style.height = '100%';
-    body.style.background = '#222';
-    body.style.color = '#fff';
-    body.style.display = 'flex';
-    body.style.alignItems = 'center';
-    body.style.justifyContent = 'center';
     this.container.appendChild(body);
+
+    this.renderer = new THREE.WebGLRenderer({ antialias: true });
+    this.renderer.setSize(body.clientWidth, body.clientHeight);
+    body.appendChild(this.renderer.domElement);
+
+    this.scene = new THREE.Scene();
+    this.scene.add(new THREE.GridHelper(10, 10));
+
+    this.camera = new THREE.PerspectiveCamera(70, body.clientWidth / body.clientHeight, 0.1, 100);
+    this.camera.position.set(5, 5, 5);
+    this.camera.lookAt(0, 0, 0);
+
+    // create cube for default instance
+    const cubeInst = this.instances.find(i => i.properties.Name === 'Cube');
+    if (cubeInst) {
+      const geom = new THREE.BoxGeometry(1, 1, 1);
+      const mat = new THREE.MeshNormalMaterial();
+      const mesh = new THREE.Mesh(geom, mat);
+      this.scene.add(mesh);
+      this.objectMap.set(cubeInst, mesh);
+    }
+
+    this.controls = new TransformControls(this.camera, this.renderer.domElement);
+    this.controls.setSpace(store.state.space);
+    this.controls.translationSnap = store.state.snap;
+    this.controls.addEventListener('objectChange', () => {
+      if (this.currentInstance) {
+        const p = this.controls.object.position;
+        const cf = `${Math.round(p.x)},${Math.round(p.y)},${Math.round(p.z)}`;
+        this.currentInstance.setProperty('CFrame', cf);
+      }
+    });
+    this.scene.add(this.controls);
+
+    const toolbar = document.createElement('div');
+    toolbar.style.position = 'absolute';
+    toolbar.style.top = '4px';
+    toolbar.style.left = '4px';
+    toolbar.style.display = 'flex';
+    toolbar.style.gap = '4px';
+    body.appendChild(toolbar);
+
+    ['translate', 'rotate', 'scale'].forEach(mode => {
+      const btn = document.createElement('button');
+      btn.textContent = mode[0].toUpperCase();
+      btn.addEventListener('click', () => {
+        this.controls.setMode(mode);
+      });
+      toolbar.appendChild(btn);
+    });
+
+    const spaceBtn = document.createElement('button');
+    spaceBtn.textContent = store.state.space === 'world' ? 'World' : 'Local';
+    spaceBtn.addEventListener('click', () => {
+      const newSpace = store.state.space === 'world' ? 'local' : 'world';
+      store.setSpace(newSpace);
+    });
+    toolbar.appendChild(spaceBtn);
+
+    const snapChk = document.createElement('input');
+    snapChk.type = 'checkbox';
+    snapChk.checked = true;
+    snapChk.addEventListener('change', () => {
+      store.setSnap(snapChk.checked ? 1 : 0);
+    });
+    toolbar.appendChild(snapChk);
+
+    store.addEventListener('space', e => {
+      this.controls.setSpace(e.detail);
+      spaceBtn.textContent = e.detail === 'world' ? 'World' : 'Local';
+    });
+    store.addEventListener('snap', e => {
+      this.controls.translationSnap = e.detail || null;
+    });
+
+    const onResize = () => {
+      const w = body.clientWidth;
+      const h = body.clientHeight;
+      this.renderer.setSize(w, h);
+      this.camera.aspect = w / h;
+      this.camera.updateProjectionMatrix();
+    };
+    window.addEventListener('resize', onResize);
+
+    const animate = () => {
+      requestAnimationFrame(animate);
+      this.renderer.render(this.scene, this.camera);
+    };
+    animate();
+  }
+
+  setInstance(inst) {
+    this.currentInstance = inst;
+    const obj = this.objectMap.get(inst);
+    if (obj) {
+      this.controls.attach(obj);
+    } else {
+      this.controls.detach();
+    }
   }
 }

--- a/packages/editor/test/gizmo.spec.js
+++ b/packages/editor/test/gizmo.spec.js
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('drag translates selected cube by 1m', async ({ page }) => {
+  await page.goto('/editor/');
+  await page.getByText('Cube').click();
+  const canvas = page.locator('#viewport canvas');
+  const box = await canvas.boundingBox();
+  const startX = box.x + box.width / 2 + 60;
+  const startY = box.y + box.height / 2;
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(startX + 80, startY);
+  await page.mouse.up();
+  const val = await page.locator('#properties input[name="CFrame"]').inputValue();
+  expect(val).toBe('1,0,0');
+});


### PR DESCRIPTION
## Summary
- add editor store for selection and gizmo options
- integrate three.js viewport with translate/rotate/scale controls and snapping
- expose cube instance transform via properties panel and Playwright test

## Testing
- `npm test` *(fails: command not found)*
- `npx playwright test packages/editor/test/gizmo.spec.js` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baacda9dcc832c99004b6c39e67140