### PR TITLE
feat: add client script hot reload

### DIFF
--- a/packages/editor/src/AppShell.js
+++ b/packages/editor/src/AppShell.js
@@ -2,6 +2,8 @@ import ExplorerPanel from './Panels/ExplorerPanel.js';
 import PropertiesPanel from './Panels/PropertiesPanel.js';
 import ViewportPanel from './Panels/ViewportPanel.js';
 import ConsolePanel from './Panels/ConsolePanel.js';
+import CodePanel from './Panels/CodePanel.js';
+import ScriptContext from '/packages/runtime-core/src/scripting/ScriptContext.js';
 
 /**
  * Editor application shell. Creates the primary dockable layout consisting of
@@ -62,6 +64,13 @@ export default class AppShell {
     this.bottomResizer.className = 'h-resizer';
     this.center.appendChild(this.bottomResizer);
 
+    // Code editor panel (fixed height)
+    this.codeEl = document.createElement('div');
+    this.codeEl.id = 'code';
+    this.codeEl.style.height = '120px';
+    this.codeEl.style.overflow = 'auto';
+    this.center.appendChild(this.codeEl);
+
     // Console panel
     this.consoleEl = document.createElement('div');
     this.consoleEl.id = 'console';
@@ -87,10 +96,13 @@ export default class AppShell {
     this.properties = new PropertiesPanel(this.propertiesEl);
     this.viewport = new ViewportPanel(this.viewportEl);
     this.console = new ConsolePanel(this.consoleEl);
+    this.scriptContext = new ScriptContext();
+    this.codeEditor = new CodePanel(this.codeEl, this.scriptContext);
 
     // Selection hookup
     this.explorer.onSelect(instance => {
       this.properties.setInstance(instance);
+      this.codeEditor.setInstance(instance);
     });
 
     // Resizers

--- a/packages/editor/src/Panels/CodePanel.js
+++ b/packages/editor/src/Panels/CodePanel.js
@@ -1,0 +1,66 @@
+import ScriptContext from '/packages/runtime-core/src/scripting/ScriptContext.js';
+
+/** Simple code editor panel with a textarea. When a script instance with a
+ * `Source` property is selected the code can be edited and executed through a
+ * ScriptContext. Only instances marked with `Kind: "Client"` are hot reloaded.
+ */
+export default class CodePanel {
+  constructor(container, context = new ScriptContext()) {
+    this.container = container;
+    this.context = context;
+    this.instance = null;
+    this.render();
+  }
+
+  setInstance(inst) {
+    this.instance = inst;
+    this.render();
+    if (inst && inst.properties.Source && inst.properties.Kind === 'Client') {
+      this.context.setScript(inst.properties.Name, inst.properties.Source);
+    }
+  }
+
+  render() {
+    this.container.innerHTML = '';
+    const title = document.createElement('div');
+    title.textContent = 'Code';
+    title.className = 'panel-title';
+    this.container.appendChild(title);
+
+    const body = document.createElement('div');
+    body.className = 'panel-body';
+    body.style.height = '100%';
+    body.style.display = 'flex';
+    body.style.flexDirection = 'column';
+
+    if (!this.instance || !this.instance.properties.Source) {
+      body.textContent = 'No script selected';
+      this.container.appendChild(body);
+      return;
+    }
+
+    const note = document.createElement('div');
+    if (this.instance.properties.Kind === 'Server') {
+      note.textContent = 'Server script – changes require restart';
+    } else {
+      note.textContent = 'Client script – edits run immediately';
+    }
+    note.style.marginBottom = '4px';
+    body.appendChild(note);
+
+    const textarea = document.createElement('textarea');
+    textarea.value = this.instance.properties.Source;
+    textarea.style.flex = '1';
+    textarea.style.width = '100%';
+    textarea.style.fontFamily = 'monospace';
+    textarea.addEventListener('input', () => {
+      this.instance.setProperty('Source', textarea.value);
+      if (this.instance.properties.Kind === 'Client') {
+        this.context.setScript(this.instance.properties.Name, textarea.value);
+      }
+    });
+    body.appendChild(textarea);
+
+    this.container.appendChild(body);
+  }
+}

--- a/packages/editor/src/Panels/ExplorerPanel.js
+++ b/packages/editor/src/Panels/ExplorerPanel.js
@@ -14,8 +14,14 @@ export default class ExplorerPanel {
   static createDefaultInstances() {
     return [
       new Instance('Workspace'),
-      new Instance('ServerScripts'),
-      new Instance('ClientScripts'),
+      new Instance('ServerScript', {
+        Source: "console.log('server script loaded')",
+        Kind: 'Server'
+      }),
+      new Instance('ClientScript', {
+        Source: "console.log('hello client')",
+        Kind: 'Client'
+      }),
       new Instance('SharedStorage')
     ];
   }

--- a/packages/editor/test/script-hot-reload.spec.js
+++ b/packages/editor/test/script-hot-reload.spec.js
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+
+test('client script hot reload', async ({ page }) => {
+  await page.goto('/editor/');
+  await page.click('text=ClientScript');
+  const consoleBody = page.locator('#console .panel-body');
+  await expect(consoleBody.locator('div').last()).toHaveText('hello client');
+  await page.fill('#code textarea', "console.log('updated')");
+  await expect(consoleBody.locator('div').last()).toHaveText('updated');
+});

--- a/packages/runtime-core/src/scripting/ScriptContext.js
+++ b/packages/runtime-core/src/scripting/ScriptContext.js
@@ -1,0 +1,41 @@
+import Signal from './Signal.js';
+
+/**
+ * Simple sandboxed script context with a minimal module system. Scripts are
+ * stored by name and evaluated in isolated functions with a shared `globals`
+ * object that persists across reloads. The context exposes an `onExecuted`
+ * signal which fires whenever a script is (re)executed.
+ */
+export default class ScriptContext {
+  constructor() {
+    this.scripts = new Map();
+    this.globals = {};
+    this.onExecuted = new Signal();
+  }
+
+  /**
+     * Load or update a script by name. The script will be immediately
+     * executed. Subsequent calls with the same name replace the module
+     * source but preserve the shared globals object.
+     */
+  setScript(name, source) {
+    this.scripts.set(name, { source, exports: {} });
+    this.#run(name);
+  }
+
+  /** Run a script and update its exports */
+  #run(name) {
+    const mod = this.scripts.get(name);
+    if (!mod) throw new Error(`Unknown script '${name}'`);
+    const module = { exports: {} };
+    const require = dep => {
+      if (!this.scripts.has(dep)) throw new Error(`Module '${dep}' not found`);
+      this.#run(dep);
+      return this.scripts.get(dep).exports;
+    };
+    const fn = new Function('module', 'exports', 'require', 'globals', 'Signal', mod.source);
+    fn(module, module.exports, require, this.globals, Signal);
+    mod.exports = module.exports;
+    this.onExecuted.dispatch(name);
+  }
+}

--- a/packages/runtime-core/src/scripting/Signal.js
+++ b/packages/runtime-core/src/scripting/Signal.js
@@ -1,0 +1,23 @@
+export default class Signal {
+  constructor() {
+    this.listeners = new Set();
+  }
+
+  add(listener) {
+    this.listeners.add(listener);
+  }
+
+  remove(listener) {
+    this.listeners.delete(listener);
+  }
+
+  dispatch(...args) {
+    for (const l of [...this.listeners]) {
+      try {
+        l(...args);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement basic Signal event utility and ScriptContext sandbox
- add simple code editor panel with hot reloading for client scripts
- test client script hot reload in Playwright

## Testing
- `npm test` *(fails: Playwright browsers missing)*
- `npx playwright install` *(fails: 403 Forbidden)*
- `npx playwright test packages/editor/test/script-hot-reload.spec.js` *(fails: missing @playwright/test package)*


------
https://chatgpt.com/codex/tasks/task_e_68baace57538832c9acf9c03ee76d435