### PR TITLE
feat(terrain): add splat rules and mask painting

### DIFF
--- a/packages/terrain/src/PaintBrush.js
+++ b/packages/terrain/src/PaintBrush.js
@@ -1,0 +1,36 @@
+/**
+ * Simple RGBA mask painting utilities.
+ * A brush write updates all channels within a circular area.
+ */
+
+/**
+ * Paint a circular brush into an RGBA mask texture.
+ *
+ * @param {Float32Array} mask   Target mask texture data.
+ * @param {number} width        Texture width in texels.
+ * @param {number} height       Texture height in texels.
+ * @param {number} cx           Brush center X.
+ * @param {number} cy           Brush center Y.
+ * @param {number} radius       Brush radius in texels.
+ * @param {number[]} color      Array of 4 values to write into the mask.
+ */
+export function paintBrush(mask, width, height, cx, cy, radius, color) {
+  const r2 = radius * radius;
+  const x0 = Math.max(0, Math.floor(cx - radius));
+  const x1 = Math.min(width - 1, Math.ceil(cx + radius));
+  const y0 = Math.max(0, Math.floor(cy - radius));
+  const y1 = Math.min(height - 1, Math.ceil(cy + radius));
+
+  for (let y = y0; y <= y1; y++) {
+    for (let x = x0; x <= x1; x++) {
+      const dx = x - cx;
+      const dy = y - cy;
+      if (dx * dx + dy * dy <= r2) {
+        const idx = (y * width + x) * 4;
+        for (let c = 0; c < 4; c++) {
+          mask[idx + c] = color[c];
+        }
+      }
+    }
+  }
+}

--- a/packages/terrain/src/SplatRules.js
+++ b/packages/terrain/src/SplatRules.js
@@ -1,0 +1,68 @@
+/**
+ * Utilities for terrain texture splatting based on height and slope rules.
+ * The CPU precompute step evaluates which rule applies per texel and
+ * prepares both the mask texture data and a packed parameter buffer for use
+ * on the GPU.
+ */
+
+/**
+ * @typedef {Object} SplatRule
+ * @property {number} minHeight - Minimum inclusive height for the rule.
+ * @property {number} maxHeight - Maximum inclusive height for the rule.
+ * @property {number} minSlope - Minimum inclusive slope for the rule (0..1).
+ * @property {number} maxSlope - Maximum inclusive slope for the rule (0..1).
+ * @property {number} layer - Output layer index (0-3 for RGBA masks).
+ */
+
+/**
+ * Precompute splat rule results for a height/slope field.
+ *
+ * @param {Float32Array} heights  Height per texel.
+ * @param {Float32Array} slopes   Slope per texel in range [0,1].
+ * @param {number} width          Width of the field in texels.
+ * @param {number} height         Height of the field in texels.
+ * @param {SplatRule[]} rules     Array of splat rules.
+ * @returns {{ params: Float32Array, masks: Float32Array }}
+ *          params - Packed GPU parameters [hMin,hMax,sMin,sMax,...].
+ *          masks  - RGBA mask texture data.
+ */
+export function precomputeSplat(heights, slopes, width, height, rules) {
+  if (heights.length !== slopes.length) {
+    throw new Error('Height and slope arrays must be the same length');
+  }
+  if (heights.length !== width * height) {
+    throw new Error('Height array length does not match dimensions');
+  }
+
+  // Pack rule parameters for GPU consumption.
+  const params = new Float32Array(rules.length * 4);
+  for (let i = 0; i < rules.length; i++) {
+    const r = rules[i];
+    params[i * 4 + 0] = r.minHeight;
+    params[i * 4 + 1] = r.maxHeight;
+    params[i * 4 + 2] = r.minSlope;
+    params[i * 4 + 3] = r.maxSlope;
+  }
+
+  // Generate mask texture data (RGBA per texel).
+  const masks = new Float32Array(width * height * 4);
+  for (let i = 0; i < heights.length; i++) {
+    const h = heights[i];
+    const s = slopes[i];
+    for (let j = 0; j < rules.length; j++) {
+      const r = rules[j];
+      if (
+        h >= r.minHeight &&
+        h <= r.maxHeight &&
+        s >= r.minSlope &&
+        s <= r.maxSlope
+      ) {
+        const channel = r.layer & 3; // clamp to 0..3
+        masks[i * 4 + channel] = 1;
+        break; // first matching rule wins
+      }
+    }
+  }
+
+  return { params, masks };
+}

--- a/packages/terrain/test/PaintBrush.test.mjs
+++ b/packages/terrain/test/PaintBrush.test.mjs
@@ -1,0 +1,14 @@
+import test from 'ava';
+import { paintBrush } from '../src/PaintBrush.js';
+
+test('brush stroke updates mask texture', t => {
+  const width = 4;
+  const height = 4;
+  const mask = new Float32Array(width * height * 4).fill(0);
+  paintBrush(mask, width, height, 1, 1, 1, [0, 0, 1, 0]);
+  const idx = (1 * width + 1) * 4;
+  t.is(mask[idx + 2], 1);
+  t.is(mask[idx], 0);
+  const outside = (0 * width + 0) * 4;
+  t.is(mask[outside + 2], 0);
+});

--- a/packages/terrain/test/SplatRules.test.mjs
+++ b/packages/terrain/test/SplatRules.test.mjs
@@ -1,0 +1,36 @@
+import test from 'ava';
+import { precomputeSplat } from '../src/SplatRules.js';
+
+// Visual verification of rule based splatting using simple height/slope data
+// The resulting mask channels indicate which texture layer is selected
+
+const width = 2;
+const height = 2;
+const heights = new Float32Array([
+  0, 10,
+  5, 15
+]);
+const slopes = new Float32Array([
+  0.1, 0.2,
+  0.8, 0.7
+]);
+
+const rules = [
+  { minHeight: 0, maxHeight: 5, minSlope: 0, maxSlope: 0.5, layer: 0 }, // grass
+  { minHeight: 0, maxHeight: 20, minSlope: 0.5, maxSlope: 1, layer: 1 }, // rock
+  { minHeight: 5, maxHeight: 20, minSlope: 0, maxSlope: 0.5, layer: 2 }  // snow
+];
+
+test('precompute generates gpu params', t => {
+  const { params } = precomputeSplat(heights, slopes, width, height, rules);
+  t.deepEqual([...params], [0, 5, 0, 0.5, 0, 20, 0.5, 1, 5, 20, 0, 0.5]);
+});
+
+test('mask assigns layers based on rules', t => {
+  const { masks } = precomputeSplat(heights, slopes, width, height, rules);
+  const px = i => [...masks.slice(i * 4, i * 4 + 4)];
+  t.deepEqual(px(0), [1, 0, 0, 0]);
+  t.deepEqual(px(1), [0, 0, 1, 0]);
+  t.deepEqual(px(2), [0, 1, 0, 0]);
+  t.deepEqual(px(3), [0, 1, 0, 0]);
+});


### PR DESCRIPTION
## Summary
- add CPU precompute for terrain texture splatting based on height/slope rules
- provide brush utility to write RGBA mask textures
- add tests for rule masks and brush painting

## Testing
- `npm run lint`
- `npm test` *(fails: Playwright browsers not installed)*
- `npx ava packages/terrain/test/*.test.mjs`
- `npm run test:visual` *(fails: Playwright browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68baacfc3544832c9cfa05a4666b39a3