### PR TITLE
feat(runtime-core): add engine loop and subsystem model

### DIFF
--- a/packages/runtime-core/src/AppLoop.js
+++ b/packages/runtime-core/src/AppLoop.js
@@ -1,0 +1,56 @@
+class AppLoop {
+  constructor(step) {
+    this._step = step;
+    this._running = false;
+    this._handle = null;
+    this._last = 0;
+    this._loop = this._loop.bind(this);
+  }
+
+  start() {
+    if (this._running) return;
+    this._running = true;
+    this._last = this._now();
+    this._handle = this._raf(this._loop);
+  }
+
+  stop() {
+    if (!this._running) return;
+    this._running = false;
+    if (this._handle !== null) {
+      this._cancel(this._handle);
+      this._handle = null;
+    }
+  }
+
+  _loop(ts) {
+    if (!this._running) return;
+    const now = this._now(ts);
+    const dt = now - this._last;
+    this._last = now;
+    this._step(dt, now);
+    this._handle = this._raf(this._loop);
+  }
+
+  _now(ts) {
+    if (typeof ts === 'number') return ts / 1000;
+    if (typeof performance !== 'undefined' && performance.now) {
+      return performance.now() / 1000;
+    }
+    return Date.now() / 1000;
+  }
+
+  _raf(cb) {
+    const raf = globalThis.requestAnimationFrame;
+    if (raf) return raf(cb);
+    return setTimeout(() => cb(Date.now()), 16);
+  }
+
+  _cancel(id) {
+    const caf = globalThis.cancelAnimationFrame;
+    if (caf) caf(id);
+    else clearTimeout(id);
+  }
+}
+
+export default AppLoop;

--- a/packages/runtime-core/src/Engine.js
+++ b/packages/runtime-core/src/Engine.js
@@ -1,0 +1,41 @@
+import AppLoop from './AppLoop.js';
+
+class Engine {
+  constructor() {
+    this._systems = [];
+    this._loop = new AppLoop(this._tick.bind(this));
+    if (typeof document !== 'undefined' && document.addEventListener) {
+      this._onVisibility = () => {
+        if (document.visibilityState === 'hidden') this._loop.stop();
+        else this._loop.start();
+      };
+      document.addEventListener('visibilitychange', this._onVisibility);
+    }
+  }
+
+  add(system) {
+    this._systems.push(system);
+  }
+
+  start() {
+    this._loop.start();
+  }
+
+  stop() {
+    this._loop.stop();
+  }
+
+  _tick(dt, time) {
+    const systems = this._systems;
+    for (let i = 0; i < systems.length; i++) {
+      const sys = systems[i];
+      if (typeof sys.update === 'function') sys.update(dt, time);
+    }
+    for (let i = 0; i < systems.length; i++) {
+      const sys = systems[i];
+      if (typeof sys.lateUpdate === 'function') sys.lateUpdate(dt, time);
+    }
+  }
+}
+
+export default Engine;

--- a/packages/runtime-core/test/Engine.test.mjs
+++ b/packages/runtime-core/test/Engine.test.mjs
@@ -1,0 +1,64 @@
+import test from 'ava';
+import Engine from '../src/Engine.js';
+
+function useFakeRAF(step = 16) {
+  let time = 0;
+  const base =
+    typeof performance !== 'undefined' && performance.now
+      ? performance.now()
+      : Date.now();
+  const raf = cb => setTimeout(() => {
+    time += step;
+    cb(base + time);
+  }, 0);
+  const caf = id => clearTimeout(id);
+  const g = globalThis;
+  const prevRAF = g.requestAnimationFrame;
+  const prevCAF = g.cancelAnimationFrame;
+  g.requestAnimationFrame = raf;
+  g.cancelAnimationFrame = caf;
+  return () => {
+    g.requestAnimationFrame = prevRAF;
+    g.cancelAnimationFrame = prevCAF;
+  };
+}
+
+test('engine loop updates subsystems and provides dt', async t => {
+  const restore = useFakeRAF();
+  const engine = new Engine();
+
+  let updates = 0;
+  let lastCall = '';
+  let lateAfterUpdate = true;
+  const dts = [];
+
+  const subsystem = {
+    update(dt) {
+      updates++;
+      dts.push(dt);
+      lastCall = 'update';
+      if (updates === 3) engine.stop();
+    },
+    lateUpdate() {
+      if (lastCall !== 'update') lateAfterUpdate = false;
+      lastCall = 'late';
+    },
+  };
+
+  engine.add(subsystem);
+
+  await new Promise(resolve => {
+    const origStop = engine.stop.bind(engine);
+    engine.stop = () => {
+      origStop();
+      resolve();
+    };
+    engine.start();
+  });
+
+  restore();
+
+  t.true(updates >= 3);
+  t.true(lateAfterUpdate);
+  t.true(dts.every(dt => dt > 0));
+});


### PR DESCRIPTION
## Summary
- add AppLoop to drive requestAnimationFrame with delta timing
- implement Engine with subsystem registration, visibility pause, and lateUpdate pass
- test engine loop for update order and positive delta time

## Testing
- `npm run lint`
- `npm run format` *(fails: Code style issues found in 16 files. Run Prettier with --write to fix.)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb3b46bf80832ca980017b75d5b7d5