### PR TITLE
feat: bridge base64 assets into binaries

### DIFF
--- a/.github/workflows/codex-assets-pr.yml
+++ b/.github/workflows/codex-assets-pr.yml
@@ -1,0 +1,56 @@
+name: Codex Assets → PR
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - codex-drafts/**
+jobs:
+  decode-and-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - name: Decode base64 assets
+        id: decode
+        run: |
+          set +e
+          node scripts/decode-assets.js
+          echo "decode_rc=$?" >> $GITHUB_OUTPUT
+          exit 0
+      - name: Bail if nothing to decode
+        if: steps.decode.outputs.decode_rc == '2'
+        run: echo "No new .b64 assets; skipping commit/PR."
+      - name: Configure git author
+        if: steps.decode.outputs.decode_rc == '0'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Commit decoded assets
+        if: steps.decode.outputs.decode_rc == '0'
+        id: commit
+        run: |
+          CHANGES=$(git status --porcelain)
+          if [ -z "$CHANGES" ]; then
+            echo "No changes after decode."
+            exit 0
+          fi
+          BRANCH="codex/assets-$(date +'%Y%m%d-%H%M%S')"
+          git checkout -b "$BRANCH"
+          git add -A
+          git commit -m "bridge: materialize binary assets from Codex"
+          git push --set-upstream origin "$BRANCH"
+          echo "branch_name=$BRANCH" >> $GITHUB_OUTPUT
+      - name: Open Pull Request
+        if: steps.decode.outputs.decode_rc == '0'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'bridge: materialize binary assets from Codex'
+          branch: ${{ steps.commit.outputs.branch_name || '' }}
+          title: 'Materialize Codex binary assets'
+          body: |
+            Auto-decoded `.b64` assets from `assets/_incoming/` into binaries under `assets/`.
+            Removed the .b64 placeholders.
+          base: main

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ build/
 .vite/
 .env
 .DS_Store
+# Visual test outputs (keep .b64 goldens tracked)
+examples/**/output.png
+examples/**/output.diff.png
+assets/_incoming/**
+!assets/_incoming/.gitkeep

--- a/docs/ASSETS_CONVENTION.md
+++ b/docs/ASSETS_CONVENTION.md
@@ -1,0 +1,7 @@
+# Asset Convention (No Raw Binaries in PRs)
+
+- Do not commit raw image binaries (e.g., .png) for goldens.
+- Commit **base64 text** files with `.png.b64` (no `data:image/...` prefix).
+- Place goldens near tests (e.g., `examples/foo/golden.png.b64`) or in `assets/_incoming/` for general assets.
+- CI will decode `assets/_incoming/*.b64` into real binaries and open a PR.
+- The visual test harness reads `.png` or `.png.b64` seamlessly.

--- a/scripts/decode-assets.js
+++ b/scripts/decode-assets.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+const INCOMING_DIR = path.join(process.cwd(), 'assets', '_incoming');
+const SIG = {
+  '.png': (b) =>
+    b.length >= 8 &&
+    b
+      .slice(0, 8)
+      .equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])),
+  '.jpg': (b) =>
+    b.length >= 3 && b.slice(0, 3).equals(Buffer.from([0xff, 0xd8, 0xff])),
+  '.jpeg': (b) =>
+    b.length >= 3 && b.slice(0, 3).equals(Buffer.from([0xff, 0xd8, 0xff])),
+  '.gif': (b) =>
+    b.length >= 6 &&
+    (b.slice(0, 6).toString('ascii') === 'GIF87a' ||
+      b.slice(0, 6).toString('ascii') === 'GIF89a'),
+  '.webp': (b) =>
+    b.length >= 12 &&
+    b.slice(0, 4).toString('ascii') === 'RIFF' &&
+    b.slice(8, 12).toString('ascii') === 'WEBP',
+};
+function walk(dir) {
+  if (!fs.existsSync(dir)) return [];
+  const out = [];
+  for (const n of fs.readdirSync(dir)) {
+    const p = path.join(dir, n);
+    const s = fs.statSync(p);
+    if (s.isDirectory()) out.push(...walk(p));
+    else if (n.endsWith('.b64')) out.push(p);
+  }
+  return out;
+}
+function ensureDir(p) {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+}
+function decodeOne(src) {
+  const raw = fs.readFileSync(src, 'utf8').replace(/\s+/g, '');
+  const base = path.basename(src).replace(/\.b64$/, ''); // e.g. foo.png
+  const ext = path.extname(base).toLowerCase();
+  const rel = path.relative(INCOMING_DIR, src).replace(/\.b64$/, ''); // keep folder structure
+  const out = path.join(
+    process.cwd(),
+    'assets',
+    rel.replace(/^_incoming[\\/]/, '')
+  );
+  const buf = Buffer.from(raw, 'base64');
+  if (SIG[ext] && !SIG[ext](buf))
+    throw new Error(`Signature check failed for ${src} (${ext})`);
+  ensureDir(out);
+  fs.writeFileSync(out, buf);
+  fs.unlinkSync(src);
+  const sha = crypto.createHash('sha256').update(buf).digest('hex');
+  console.log(`Decoded: ${out} (${buf.length} bytes) sha256=${sha}`);
+}
+const files = walk(INCOMING_DIR);
+if (!files.length) {
+  console.log('No *.b64 assets found. Nothing to decode.');
+  process.exit(2);
+}
+for (const f of files) decodeOne(f);

--- a/tools/pixel-compare.mjs
+++ b/tools/pixel-compare.mjs
@@ -1,3 +1,59 @@
-export function pixelCompare() {
-  console.log('pixel compare placeholder');
+import { chromium } from 'playwright';
+import pixelmatch from 'pixelmatch';
+import { PNG } from 'pngjs';
+import fs from 'node:fs';
+
+function readPngOrB64(pathPng) {
+  const b64Path = pathPng + '.b64';
+  if (fs.existsSync(pathPng)) {
+    const buf = fs.readFileSync(pathPng);
+    return PNG.sync.read(buf);
+  }
+  if (fs.existsSync(b64Path)) {
+    const raw = fs.readFileSync(b64Path, 'utf8').replace(/\s+/g, '');
+    const buf = Buffer.from(raw, 'base64');
+    return PNG.sync.read(buf);
+  }
+  throw new Error(`Missing golden: ${pathPng} or ${b64Path}`);
 }
+
+const url = 'http://localhost:5173/examples/hello-triangle/index.html';
+const goldenPath = './examples/hello-triangle/golden.png';
+const out = './examples/hello-triangle/output.png';
+const diff = './examples/hello-triangle/output.diff.png';
+
+async function main() {
+  const browser = await chromium.launch({ args: ['--enable-unsafe-webgpu'] });
+  const page = await browser.newPage();
+  await page.goto(url, { waitUntil: 'networkidle' });
+  await page.waitForTimeout(300);
+  const buf = await page.screenshot({ fullPage: false });
+  fs.writeFileSync(out, buf);
+
+  const gold = readPngOrB64(goldenPath);
+  const shot = PNG.sync.read(fs.readFileSync(out));
+  const { width, height } = gold;
+  if (shot.width !== width || shot.height !== height) {
+    throw new Error(
+      `Size mismatch: got ${shot.width}x${shot.height}, expected ${width}x${height}`
+    );
+  }
+  const diffImg = new PNG({ width, height });
+  const mismatched = pixelmatch(
+    gold.data,
+    shot.data,
+    diffImg.data,
+    width,
+    height,
+    { threshold: 0.1 }
+  );
+  fs.writeFileSync(diff, PNG.sync.write(diffImg));
+  const pct = mismatched / (width * height);
+  console.log('pixelsDifferent', mismatched, 'ratio', pct.toFixed(4));
+  process.exit(pct > 0.02 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- decode base64 assets and materialize binaries via GitHub Action
- support `.png.b64` goldens in visual pixel comparison
- document convention to commit image goldens as base64 text

## Testing
- `node scripts/decode-assets.js`
- `npm run lint`
- `npm run format` *(fails: Code style issues found in 19 files. Run Prettier with --write to fix.)*
- `npx prettier scripts/decode-assets.js tools/pixel-compare.mjs .github/workflows/codex-assets-pr.yml docs/ASSETS_CONVENTION.md --check`
- `npm test`
- `npm run test:visual`


------
https://chatgpt.com/codex/tasks/task_e_68bb42124e98832c9e51a85303e45f55