### PR TITLE
Implement Services registry with tests

### DIFF
--- a/packages/runtime-core/src/core/Services.js
+++ b/packages/runtime-core/src/core/Services.js
@@ -1,0 +1,39 @@
+const registry = new Map();
+
+const Services = {
+  /**
+   * Retrieve a service by name.
+   * @param {string} name
+   * @returns {*}
+   */
+  get(name) {
+    return registry.get(name);
+  },
+
+  /**
+   * Register a service instance.
+   * @param {string} name
+   * @param {*} instance
+   */
+  set(name, instance) {
+    registry.set(name, instance);
+  },
+
+  /**
+   * Check if a service exists.
+   * @param {string} name
+   * @returns {boolean}
+   */
+  has(name) {
+    return registry.has(name);
+  },
+
+  /**
+   * Clear all registered services.
+   */
+  clear() {
+    registry.clear();
+  },
+};
+
+export default Services;

--- a/packages/runtime-core/test/Services.test.mjs
+++ b/packages/runtime-core/test/Services.test.mjs
@@ -1,0 +1,26 @@
+import test from 'ava';
+import Services from '../src/core/Services.js';
+
+test.beforeEach(() => {
+  Services.clear();
+});
+
+test('set and get a service', t => {
+  const service = {foo: 'bar'};
+  Services.set('svc', service);
+  t.is(Services.get('svc'), service);
+});
+
+test('has determines existence', t => {
+  const service = {};
+  Services.set('a', service);
+  t.true(Services.has('a'));
+  t.false(Services.has('b'));
+});
+
+test('clear removes all services', t => {
+  Services.set('a', {});
+  Services.clear();
+  t.false(Services.has('a'));
+  t.is(Services.get('a'), undefined);
+});


### PR DESCRIPTION
## Summary
- add minimal service registry with get/set/has/clear
- test service registration lifecycle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb47753e34832c853cc200d760506e