### PR TITLE
feat: add dev server and lint/format configs

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,8 +1,8 @@
 export default [
   {
-    files: ["**/*.js", "**/*.mjs"],
-    ignores: ["node_modules", "dist"],
-    languageOptions: { ecmaVersion: 2020, sourceType: "module" },
-    rules: {}
-  }
+    files: ['**/*.{js,mjs}'],
+    ignores: ['node_modules', 'dist'],
+    languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+    rules: {},
+  },
 ];

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,5 +1,6 @@
 export default {
   printWidth: 80,
   singleQuote: true,
-  trailingComma: 'es5',
+  trailingComma: 'all',
+  semi: true,
 };

--- a/scripts/dev-server.mjs
+++ b/scripts/dev-server.mjs
@@ -1,9 +1,12 @@
 import { createServer } from 'vite';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 async function start() {
-  const server = await createServer({
-    root: 'examples/hello-triangle',
-  });
+  const root = resolve(__dirname, '../examples/hello-triangle');
+  const server = await createServer({ root });
   await server.listen();
   server.printUrls();
 }


### PR DESCRIPTION
## Summary
- start Vite dev server for hello-triangle example
- add baseline ESLint and Prettier configs

## Testing
- `npm run dev`
- `npm run lint`
- `npm run format` *(fails: Code style issues found in 18 files. Run Prettier with --write to fix.)*

------
https://chatgpt.com/codex/tasks/task_e_68bb488cca74832c904b41bad7bb60f8