### PR TITLE
feat: add PBR metal-rough material and color helpers

### DIFF
--- a/packages/renderer-webgpu/src/Materials/PBRMetalRough.js
+++ b/packages/renderer-webgpu/src/Materials/PBRMetalRough.js
@@ -1,0 +1,72 @@
+export function srgbToLinear(color) {
+  const convert = (v) =>
+    v <= 0.04045 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  if (Array.isArray(color)) {
+    return color.map(convert);
+  }
+  return convert(color);
+}
+
+export function linearToSrgb(color) {
+  const convert = (v) =>
+    v <= 0.0031308 ? v * 12.92 : 1.055 * Math.pow(v, 1 / 2.4) - 0.055;
+  if (Array.isArray(color)) {
+    return color.map(convert);
+  }
+  return convert(color);
+}
+
+export function tonemapACES(color) {
+  const a = 2.51;
+  const b = 0.03;
+  const c = 2.43;
+  const d = 0.59;
+  const e = 0.14;
+  const convert = (v) => {
+    const num = v * (a * v + b);
+    const denom = v * (c * v + d) + e;
+    return Math.min(Math.max(num / denom, 0), 1);
+  };
+  if (Array.isArray(color)) {
+    return color.map(convert);
+  }
+  return convert(color);
+}
+
+export class PBRMetalRough {
+  constructor({
+    baseColor = [1, 1, 1, 1],
+    metallic = 1,
+    roughness = 1,
+    normal = null,
+    occlusion = null,
+    emissive = [0, 0, 0],
+  } = {}) {
+    this.baseColor = baseColor;
+    this.metallic = metallic;
+    this.roughness = roughness;
+    this.normal = normal;
+    this.occlusion = occlusion;
+    this.emissive = emissive;
+
+    // Param block for uniform buffer
+    this.paramBuffer = new Float32Array(12);
+    this._updateParams();
+  }
+
+  _updateParams() {
+    const p = this.paramBuffer;
+    p.set(this.baseColor, 0); // rgba
+    p[4] = this.metallic;
+    p[5] = this.roughness;
+    p.set(this.emissive, 6);
+  }
+
+  get params() {
+    this._updateParams();
+    return this.paramBuffer;
+  }
+}
+
+export default PBRMetalRough;
+

--- a/packages/renderer-webgpu/src/Materials/pbr.wgsl
+++ b/packages/renderer-webgpu/src/Materials/pbr.wgsl
@@ -1,0 +1,32 @@
+const PI : f32 = 3.141592653589793;
+
+struct PBRParams {
+  baseColor : vec4<f32>;
+  metallic : f32;
+  roughness : f32;
+  emissive : vec3<f32>;
+};
+
+fn D_GGX(NdotH: f32, roughness: f32) -> f32 {
+  let a = roughness * roughness;
+  let a2 = a * a;
+  let denom = (NdotH * NdotH) * (a2 - 1.0) + 1.0;
+  return a2 / (PI * denom * denom);
+}
+
+fn G_SchlickGGX(NdotV: f32, k: f32) -> f32 {
+  return NdotV / (NdotV * (1.0 - k) + k);
+}
+
+fn G_Smith(NdotV: f32, NdotL: f32, roughness: f32) -> f32 {
+  let r = roughness + 1.0;
+  let k = (r * r) / 8.0;
+  let g1 = G_SchlickGGX(NdotV, k);
+  let g2 = G_SchlickGGX(NdotL, k);
+  return g1 * g2;
+}
+
+fn F_Schlick(VdotH: f32, F0: vec3<f32>) -> vec3<f32> {
+  return F0 + (1.0 - F0) * pow(1.0 - VdotH, 5.0);
+}
+

--- a/packages/renderer-webgpu/test/Color.test.mjs
+++ b/packages/renderer-webgpu/test/Color.test.mjs
@@ -1,0 +1,21 @@
+import test from 'ava';
+import {
+  srgbToLinear,
+  linearToSrgb,
+  tonemapACES,
+} from '../src/Materials/PBRMetalRough.js';
+
+test('sRGB to linear and back', t => {
+  const src = [0, 0.5, 1];
+  const linear = srgbToLinear(src);
+  const round = linearToSrgb(linear);
+  for (let i = 0; i < src.length; i++) {
+    t.true(Math.abs(src[i] - round[i]) < 1e-6);
+  }
+});
+
+test('ACES tonemap clamps HDR values', t => {
+  const color = [2, 4, 8];
+  const mapped = tonemapACES(color);
+  mapped.forEach(v => t.true(v >= 0 && v <= 1));
+});


### PR DESCRIPTION
## Summary
- add PBRMetalRough material with uniform param block
- include WGSL BRDF helpers for GGX/Smith/Schlick
- provide sRGB-linear conversion and ACES tonemap utilities with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb4be239f8832ca2d588493e81773f