### PR TITLE
feat: add script context and hot reload

### DIFF
--- a/packages/editor/src/Panels/ScriptEditorPanel.js
+++ b/packages/editor/src/Panels/ScriptEditorPanel.js
@@ -1,0 +1,17 @@
+// Simple script editor panel with text area bound to a ScriptContext.
+export default function ScriptEditorPanel(context, name = 'Main') {
+  const el = document.createElement('div');
+  el.id = 'script-editor-panel';
+  el.className = 'panel';
+  el.innerHTML = `
+    <div class="panel-header">Script Editor</div>
+    <div class="panel-body">
+      <textarea style="width:100%;height:100%;"></textarea>
+    </div>
+  `;
+  const textarea = el.querySelector('textarea');
+  textarea.addEventListener('input', () => {
+    context.load(name, textarea.value);
+  });
+  return el;
+}

--- a/packages/editor/test/script-reload.test.js
+++ b/packages/editor/test/script-reload.test.js
@@ -1,0 +1,47 @@
+import test from 'ava';
+import { chromium } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Ensure editing the script updates behavior without page reload.
+
+test('script hot reload', async t => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+
+  const panelURL = pathToFileURL(path.join(__dirname, '../src/Panels/ScriptEditorPanel.js')).href;
+  const ctxURL = pathToFileURL(path.join(__dirname, '../../runtime-core/src/scripting/ScriptContext.js')).href;
+
+  const setup = `
+    import ScriptEditorPanel from '${panelURL}';
+    import ScriptContext from '${ctxURL}';
+    const ctx = new ScriptContext();
+    const panel = ScriptEditorPanel(ctx, 'Main');
+    document.body.appendChild(panel);
+    const out = document.createElement('div');
+    out.id = 'out';
+    document.body.appendChild(out);
+    window.ctx = ctx; // expose for debugging
+  `;
+  await page.addScriptTag({ type: 'module', content: setup });
+
+  // initial script
+  await page.evaluate(() => {
+    const textarea = document.querySelector('textarea');
+    textarea.value = "document.getElementById('out').textContent = 'A';";
+    textarea.dispatchEvent(new Event('input'));
+  });
+  t.is(await page.textContent('#out'), 'A');
+
+  // edit script to update DOM
+  await page.evaluate(() => {
+    const textarea = document.querySelector('textarea');
+    textarea.value = "document.getElementById('out').textContent = 'B';";
+    textarea.dispatchEvent(new Event('input'));
+  });
+  t.is(await page.textContent('#out'), 'B');
+
+  await browser.close();
+});

--- a/packages/runtime-core/src/scripting/ScriptContext.js
+++ b/packages/runtime-core/src/scripting/ScriptContext.js
@@ -1,0 +1,38 @@
+import Signal from './Signal.js';
+
+// Simple sandboxed script loader with hot-reload support.
+class ScriptContext {
+  constructor(env = {}) {
+    this.env = env;
+    this._scripts = new Map();
+    this.changed = new Signal();
+  }
+
+  // Load or reload a script by name.
+  load(name, code) {
+    const existing = this._scripts.get(name);
+    if (existing && typeof existing.dispose === 'function') {
+      try {
+        existing.dispose();
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
+    const sandbox = { ...this.env, Signal };
+    const module = { exports: {} };
+    const keys = Object.keys(sandbox);
+    const values = Object.values(sandbox);
+    const func = new Function('exports', 'module', ...keys, code);
+    func(module.exports, module, ...values);
+    const script = module.exports.default || module.exports;
+    let dispose;
+    if (typeof script === 'function') {
+      dispose = script();
+    }
+    this._scripts.set(name, { dispose });
+    this.changed.fire(name);
+  }
+}
+
+export default ScriptContext;

--- a/packages/runtime-core/src/scripting/Signal.js
+++ b/packages/runtime-core/src/scripting/Signal.js
@@ -1,0 +1,26 @@
+class Signal {
+  constructor() {
+    this._listeners = new Set();
+  }
+
+  connect(fn) {
+    this._listeners.add(fn);
+    return {
+      disconnect: () => {
+        this._listeners.delete(fn);
+      },
+    };
+  }
+
+  fire(...args) {
+    for (const fn of [...this._listeners]) {
+      try {
+        fn(...args);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+  }
+}
+
+export default Signal;


### PR DESCRIPTION
## Summary
- add Signal utility for event-style callbacks
- implement ScriptContext sandbox loader with hot reload
- provide ScriptEditorPanel with live text editing
- add playwright test for client script hot reload

## Testing
- `npm run test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9993f42c832ca3002ffb5126dae7