### PR TITLE
feat: add terrain brush controls and undo stack

### DIFF
--- a/packages/editor/src/Commands/UndoRedo.js
+++ b/packages/editor/src/Commands/UndoRedo.js
@@ -1,0 +1,27 @@
+export default class UndoRedo {
+  constructor(limit = 50) {
+    this.limit = limit;
+    this.undoStack = [];
+    this.redoStack = [];
+  }
+
+  push(cmd) {
+    this.undoStack.push(cmd);
+    if (this.undoStack.length > this.limit) this.undoStack.shift();
+    this.redoStack.length = 0;
+  }
+
+  undo() {
+    const cmd = this.undoStack.pop();
+    if (!cmd) return;
+    cmd.undo();
+    this.redoStack.push(cmd);
+  }
+
+  redo() {
+    const cmd = this.redoStack.pop();
+    if (!cmd) return;
+    cmd.redo();
+    this.undoStack.push(cmd);
+  }
+}

--- a/packages/editor/src/Panels/TerrainPanel.js
+++ b/packages/editor/src/Panels/TerrainPanel.js
@@ -1,19 +1,41 @@
 import DestructionMasks from '../../../terrain/src/DestructionMasks.js';
 import SplatRules from '../../../terrain/src/SplatRules.js';
+import UndoRedo from '../Commands/UndoRedo.js';
 
 export default function TerrainPanel() {
   const el = document.createElement('div');
   el.id = 'terrain-panel';
   el.className = 'panel';
-  el.innerHTML = `<div class="panel-header">Terrain</div><canvas width="64" height="64"></canvas>`;
+  el.innerHTML = `
+    <div class="panel-header">Terrain</div>
+    <div class="panel-body">
+      <div class="controls">
+        <label>Size <input type="range" id="brush-size" min="1" max="32" value="10"></label>
+        <label>Strength <input type="range" id="brush-strength" min="0" max="1" step="0.01" value="1"></label>
+        <label>Falloff <input type="range" id="brush-falloff" min="0" max="1" step="0.01" value="0.5"></label>
+        <button id="undo-btn">Undo</button>
+        <button id="redo-btn">Redo</button>
+        <button id="save-btn">Save</button>
+        <button id="load-btn">Load</button>
+      </div>
+      <canvas width="64" height="64"></canvas>
+    </div>`;
 
   const canvas = el.querySelector('canvas');
   const ctx = canvas.getContext('2d');
+  const sizeInput = el.querySelector('#brush-size');
+  const strengthInput = el.querySelector('#brush-strength');
+  const falloffInput = el.querySelector('#brush-falloff');
+  const undoBtn = el.querySelector('#undo-btn');
+  const redoBtn = el.querySelector('#redo-btn');
+  const saveBtn = el.querySelector('#save-btn');
+  const loadBtn = el.querySelector('#load-btn');
 
   const masks = new DestructionMasks(64, 64);
-  const rules = new SplatRules([
+  let rules = new SplatRules([
     { height: [-Infinity, Infinity], slope: [-Infinity, Infinity], color: [0, 255, 0, 255] }
   ]);
+  const stack = new UndoRedo();
 
   const base = rules.evaluate(0, 0);
   if (base) masks.fill(base.color);
@@ -23,14 +45,84 @@ export default function TerrainPanel() {
     ctx.putImageData(img, 0, 0);
   }
 
+  function paint(x, y) {
+    const radius = parseInt(sizeInput.value, 10);
+    const strength = parseFloat(strengthInput.value);
+    const falloff = parseFloat(falloffInput.value);
+    const color = [255, 0, 0, 255];
+
+    const before = new Uint8ClampedArray(masks.data);
+    for (let j = 0; j < masks.height; j++) {
+      for (let i = 0; i < masks.width; i++) {
+        const dx = i - x;
+        const dy = j - y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        if (dist <= radius) {
+          const t = 1 - dist / radius;
+          const f = Math.pow(t, falloff * 4 + 1) * strength;
+          const idx = (j * masks.width + i) * 4;
+          for (let k = 0; k < 4; k++) {
+            const current = masks.data[idx + k];
+            const target = color[k];
+            masks.data[idx + k] = Math.round(current + (target - current) * f);
+          }
+        }
+      }
+    }
+    redraw();
+    const after = new Uint8ClampedArray(masks.data);
+    stack.push({
+      undo: () => {
+        masks.data.set(before);
+        redraw();
+      },
+      redo: () => {
+        masks.data.set(after);
+        redraw();
+      }
+    });
+  }
+
   canvas.addEventListener('click', e => {
     const rect = canvas.getBoundingClientRect();
     const x = e.clientX - rect.left;
     const y = e.clientY - rect.top;
-    masks.applyBrush(x, y, 10, [255, 0, 0, 255]);
+    paint(x, y);
+  });
+
+  undoBtn.addEventListener('click', () => stack.undo());
+  redoBtn.addEventListener('click', () => stack.redo());
+
+  saveBtn.addEventListener('click', () => {
+    const json = JSON.stringify({
+      width: masks.width,
+      height: masks.height,
+      data: Array.from(masks.data),
+      rules: rules.serialize()
+    });
+    window.lastTerrainSave = json;
+  });
+
+  loadBtn.addEventListener('click', () => {
+    if (!window.lastTerrainSave) return;
+    const obj = JSON.parse(window.lastTerrainSave);
+    masks.data.set(obj.data);
+    rules = SplatRules.deserialize(obj.rules);
     redraw();
   });
 
   redraw();
+
+  window.terrain = {
+    get masks() {
+      return masks;
+    },
+    get rules() {
+      return rules;
+    },
+    stack,
+    canvas
+  };
+
   return el;
 }

--- a/packages/editor/test/terrain-panel.test.js
+++ b/packages/editor/test/terrain-panel.test.js
@@ -1,0 +1,47 @@
+import test from 'ava';
+import { chromium } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Verify painting with undo/redo and save/load
+
+test('terrain paint undo/redo and save/load', async t => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.setViewportSize({ width: 100, height: 100 });
+
+  const terrainURL = pathToFileURL(path.join(__dirname, '../src/Panels/TerrainPanel.js')).href;
+  const script = `
+    import TerrainPanel from '${terrainURL}';
+    const panel = TerrainPanel();
+    document.body.appendChild(panel);
+  `;
+  await page.addScriptTag({ type: 'module', content: script });
+
+  const initial = await page.evaluate(() => Array.from(window.terrain.masks.data));
+
+  await page.click('canvas', { position: { x: 10, y: 10 } });
+  const painted = await page.evaluate(() => Array.from(window.terrain.masks.data));
+  t.notDeepEqual(painted, initial);
+
+  await page.click('#undo-btn');
+  const afterUndo = await page.evaluate(() => Array.from(window.terrain.masks.data));
+  t.deepEqual(afterUndo, initial);
+
+  await page.click('#redo-btn');
+  const afterRedo = await page.evaluate(() => Array.from(window.terrain.masks.data));
+  t.deepEqual(afterRedo, painted);
+
+  await page.click('#save-btn');
+  await page.click('canvas', { position: { x: 20, y: 20 } });
+  const modified = await page.evaluate(() => Array.from(window.terrain.masks.data));
+  t.notDeepEqual(modified, painted);
+
+  await page.click('#load-btn');
+  const afterLoad = await page.evaluate(() => Array.from(window.terrain.masks.data));
+  t.deepEqual(afterLoad, painted);
+
+  await browser.close();
+});

--- a/packages/terrain/src/SplatRules.js
+++ b/packages/terrain/src/SplatRules.js
@@ -14,4 +14,19 @@ export default class SplatRules {
     }
     return null;
   }
+
+  // Serialize rules to JSON string
+  serialize() {
+    return JSON.stringify(this.rules);
+  }
+
+  // Deserialize from JSON string
+  static deserialize(json) {
+    try {
+      const rules = JSON.parse(json);
+      return new SplatRules(rules);
+    } catch (e) {
+      return new SplatRules();
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add brush size, strength, and falloff controls to terrain panel
- implement undo/redo command stack and save/load functionality
- serialize terrain splat rules for persistence

## Testing
- `npm run lint`
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*


------
https://chatgpt.com/codex/tasks/task_e_68bbe232a76c832cb89901eb76f3800d