### PR TITLE
feat: add voxel edit brushes and persistence

### DIFF
--- a/packages/editor/src/Panels/VoxelPanel.js
+++ b/packages/editor/src/Panels/VoxelPanel.js
@@ -1,0 +1,59 @@
+import ChunkStore from '../../../voxels/src/ChunkStore.js';
+
+export default class VoxelPanel {
+  constructor() {
+    this.store = new ChunkStore();
+    this.el = document.createElement('div');
+
+    const radius = document.createElement('input');
+    radius.type = 'number';
+    radius.value = 4;
+    const strength = document.createElement('input');
+    strength.type = 'number';
+    strength.value = 1;
+    const falloff = document.createElement('input');
+    falloff.type = 'number';
+    falloff.value = 1;
+
+    const makeParams = () => ({
+      radius: parseFloat(radius.value),
+      strength: parseFloat(strength.value),
+      falloff: parseFloat(falloff.value),
+    });
+
+    const addBtn = document.createElement('button');
+    addBtn.textContent = 'Add';
+    addBtn.onclick = () => {
+      this.store.applyEdit({ op: 'add', shape: 'sphere', params: makeParams() });
+    };
+
+    const subBtn = document.createElement('button');
+    subBtn.textContent = 'Subtract';
+    subBtn.onclick = () => {
+      this.store.applyEdit({ op: 'subtract', shape: 'sphere', params: makeParams() });
+    };
+
+    const smoothBtn = document.createElement('button');
+    smoothBtn.textContent = 'Smooth';
+    smoothBtn.onclick = () => {
+      this.store.applyEdit({ op: 'smooth', shape: 'sphere', params: makeParams() });
+    };
+
+    const saveBtn = document.createElement('button');
+    saveBtn.textContent = 'Save';
+    saveBtn.onclick = () => {
+      const json = this.store.saveDeltas();
+      localStorage.setItem('voxelDeltas', json);
+    };
+
+    const loadBtn = document.createElement('button');
+    loadBtn.textContent = 'Load';
+    loadBtn.onclick = () => {
+      const json = localStorage.getItem('voxelDeltas');
+      if (json) this.store.loadDeltas(json);
+    };
+
+    this.el.append(radius, strength, falloff, addBtn, subBtn, smoothBtn, saveBtn, loadBtn);
+  }
+}
+

--- a/packages/voxels/src/EditOps.js
+++ b/packages/voxels/src/EditOps.js
@@ -1,0 +1,64 @@
+export default class EditOps {
+  constructor(store) {
+    this.store = store;
+  }
+
+  apply(op, shape, params = {}) {
+    if (shape !== 'sphere') return [];
+    const {
+      chunkId = '0,0,0',
+      x = this.store.chunkSize / 2,
+      y = this.store.chunkSize / 2,
+      z = this.store.chunkSize / 2,
+      radius = this.store.chunkSize / 4,
+      strength = 1,
+      falloff = 1,
+    } = params;
+    const chunk = this.store._ensureChunk(chunkId);
+    const N = this.store.gridSize;
+    const sdf = chunk.sdf;
+    for (let zz = 0; zz < N; zz++) {
+      for (let yy = 0; yy < N; yy++) {
+        for (let xx = 0; xx < N; xx++) {
+          const dx = xx - x;
+          const dy = yy - y;
+          const dz = zz - z;
+          const dist = Math.hypot(dx, dy, dz);
+          const influence = Math.pow(Math.max(0, 1 - dist / radius), falloff);
+          if (influence <= 0) continue;
+          const delta = strength * influence;
+          const idx = xx + yy * N + zz * N * N;
+          if (op === 'add') {
+            sdf[idx] = Math.min(sdf[idx], -delta);
+          } else if (op === 'subtract') {
+            sdf[idx] = Math.max(sdf[idx], delta);
+          } else if (op === 'smooth') {
+            let sum = 0;
+            let count = 0;
+            const neighbors = [
+              [1, 0, 0],
+              [-1, 0, 0],
+              [0, 1, 0],
+              [0, -1, 0],
+              [0, 0, 1],
+              [0, 0, -1],
+            ];
+            for (const [ox, oy, oz] of neighbors) {
+              const nx = xx + ox;
+              const ny = yy + oy;
+              const nz = zz + oz;
+              if (nx < 0 || ny < 0 || nz < 0 || nx >= N || ny >= N || nz >= N) continue;
+              const nIdx = nx + ny * N + nz * N * N;
+              sum += sdf[nIdx];
+              count++;
+            }
+            const avg = count ? sum / count : sdf[idx];
+            sdf[idx] = sdf[idx] * (1 - delta) + avg * delta;
+          }
+        }
+      }
+    }
+    return [chunkId];
+  }
+}
+

--- a/packages/voxels/test/Persistence.test.mjs
+++ b/packages/voxels/test/Persistence.test.mjs
@@ -1,0 +1,29 @@
+import test from 'ava';
+import ChunkStore from '../src/ChunkStore.js';
+
+function checksum(mesh) {
+  return mesh.positions.reduce((s, v) => s + Math.round(v * 1000), 0);
+}
+
+test('save and load deltas reproduces mesh', async t => {
+  const storeA = new ChunkStore();
+  storeA.applyEdit({
+    op: 'add',
+    shape: 'sphere',
+    params: { chunkId: '0,0,0', x: 10, y: 10, z: 10, radius: 6, strength: 1, falloff: 1 },
+  });
+  const meshA = await storeA.getChunkMesh('0,0,0');
+  const vA = meshA.positions.length / 3;
+  const cA = checksum(meshA);
+
+  const json = storeA.saveDeltas();
+  const storeB = new ChunkStore();
+  storeB.loadDeltas(json);
+  const meshB = await storeB.getChunkMesh('0,0,0');
+  const vB = meshB.positions.length / 3;
+  const cB = checksum(meshB);
+
+  t.is(vA, vB);
+  t.is(cA, cB);
+});
+


### PR DESCRIPTION
## Summary
- add additive, subtractive, and smoothing voxel brushes with radius, strength, and falloff controls
- persist voxel edits as deltas with save/load helpers
- expose voxel editing panel and unit test for delta replay

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist; run npx playwright install)*
- `npx playwright install` *(fails: Download failed: server returned code 403 body 'Forbidden')*


------
https://chatgpt.com/codex/tasks/task_e_68bc63a2a6d4832cac908759856b1c40