### PR TITLE
feat: add signal-based Instance system

### DIFF
--- a/engine/core/index.js
+++ b/engine/core/index.js
@@ -1,22 +1,116 @@
 import Lighting from '../services/Lighting.js';
+import { Signal } from './signal.js';
+import { isValidAttribute } from './types.js';
 
-export class Instance {
-  constructor(name) {
-    this.name = name;
-    this.children = [];
-    this.parent = null;
+class Instance {
+  constructor(className = 'Instance') {
+    this.ClassName = className;
+    this.Name = className;
+    this.Children = [];
+    this.Attributes = new Map();
+    this._parent = null;
+
+    this.AncestryChanged = new Signal();
+    this.ChildAdded = new Signal();
+    this.ChildRemoved = new Signal();
+    this.Changed = new Signal();
   }
+
+  get Parent() {
+    return this._parent;
+  }
+
+  set Parent(newParent) {
+    this.setParent(newParent);
+  }
+
+  setParent(newParent) {
+    if (this._parent === newParent) return;
+    const oldParent = this._parent;
+    if (oldParent) {
+      const idx = oldParent.Children.indexOf(this);
+      if (idx !== -1) oldParent.Children.splice(idx, 1);
+      oldParent.ChildRemoved.Fire(this);
+    }
+
+    this._parent = newParent;
+    this.Changed.Fire('Parent');
+
+    if (newParent) {
+      newParent.Children.push(this);
+      newParent.ChildAdded.Fire(this);
+    }
+
+    const affected = [this, ...this.GetDescendants()];
+    for (const inst of affected) {
+      inst.AncestryChanged.Fire(inst, inst.Parent);
+    }
+  }
+
+  setProperty(name, value) {
+    if (this[name] === value) return;
+    this[name] = value;
+    this.Changed.Fire(name);
+  }
+
   Add(child) {
-    child.parent = this;
-    this.children.push(child);
+    child.Parent = this;
+  }
+
+  Remove() {
+    this.ClearAllChildren();
+    this.Parent = null;
+  }
+
+  FindFirstChild(name) {
+    return this.Children.find(c => c.Name === name) || null;
+  }
+
+  GetChildren() {
+    return [...this.Children];
+  }
+
+  GetDescendants() {
+    const result = [];
+    const walk = obj => {
+      for (const child of obj.Children) {
+        result.push(child);
+        walk(child);
+      }
+    };
+    walk(this);
+    return result;
+  }
+
+  SetAttribute(k, v) {
+    if (!isValidAttribute(v)) throw new Error('Invalid attribute value');
+    this.Attributes.set(k, v);
+    this.Changed.Fire(k);
+  }
+
+  GetAttribute(k) {
+    return this.Attributes.get(k);
+  }
+
+  GetAttributes() {
+    return Object.fromEntries(this.Attributes.entries());
+  }
+
+  ClearAllChildren() {
+    for (const child of [...this.Children]) {
+      child.Parent = null;
+    }
   }
 }
 
 const Services = new Map();
-Services.set('Lighting', new Lighting());
 
-export function GetService(name) {
+const lighting = new Instance('Lighting');
+Object.assign(lighting, new Lighting());
+Services.set('Lighting', lighting);
+
+function GetService(name) {
   return Services.get(name);
 }
 
-export { Services };
+export { Instance, Services, GetService };

--- a/engine/core/signal.js
+++ b/engine/core/signal.js
@@ -1,0 +1,52 @@
+class Signal {
+  constructor() {
+    this.connections = new Set();
+  }
+
+  Connect(fn) {
+    const connection = {
+      connected: true,
+      Disconnect: () => {
+        if (connection.connected) {
+          connection.connected = false;
+          this.connections.delete(connection);
+        }
+      },
+      fn,
+    };
+    this.connections.add(connection);
+    return connection;
+  }
+
+  Once(fn) {
+    const connection = this.Connect((...args) => {
+      connection.Disconnect();
+      fn(...args);
+    });
+    return connection;
+  }
+
+  Wait() {
+    return new Promise(resolve => this.Once(resolve));
+  }
+
+  Fire(...args) {
+    for (const connection of Array.from(this.connections)) {
+      try {
+        connection.fn(...args);
+      } catch (e) {
+        // swallow errors to not break other listeners
+        console.error(e);
+      }
+    }
+  }
+
+  DisconnectAll() {
+    for (const connection of this.connections) {
+      connection.connected = false;
+    }
+    this.connections.clear();
+  }
+}
+
+export { Signal };

--- a/engine/core/types.js
+++ b/engine/core/types.js
@@ -1,0 +1,31 @@
+function isVector3(v) {
+  return v && typeof v === 'object'
+    && typeof v.x === 'number'
+    && typeof v.y === 'number'
+    && typeof v.z === 'number';
+}
+
+function isColor3(v) {
+  return v && typeof v === 'object'
+    && typeof v.r === 'number' && v.r >= 0 && v.r <= 1
+    && typeof v.g === 'number' && v.g >= 0 && v.g <= 1
+    && typeof v.b === 'number' && v.b >= 0 && v.b <= 1;
+}
+
+function isJSONSerializable(v) {
+  try {
+    JSON.stringify(v);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isValidAttribute(v) {
+  const type = typeof v;
+  if (type === 'string' || type === 'number' || type === 'boolean') return true;
+  if (isVector3(v) || isColor3(v)) return true;
+  return isJSONSerializable(v);
+}
+
+export { isVector3, isColor3, isValidAttribute };

--- a/tests/ava/basic.test.js
+++ b/tests/ava/basic.test.js
@@ -11,6 +11,6 @@ test('instances parent and child correctly', t => {
   const parent = new Instance('Parent');
   const child = new Instance('Child');
   parent.Add(child);
-  t.is(child.parent, parent);
-  t.true(parent.children.includes(child));
+  t.is(child.Parent, parent);
+  t.true(parent.Children.includes(child));
 });

--- a/tests/ava/instance-signals.test.js
+++ b/tests/ava/instance-signals.test.js
@@ -1,0 +1,47 @@
+import test from 'ava';
+import { Instance } from '../../engine/core/index.js';
+
+// ChildAdded/Removed order
+// Reparent child from A to B and check event order
+
+test('ChildAdded/Removed order on reparent', t => {
+  const a = new Instance('A');
+  const b = new Instance('B');
+  const child = new Instance('Child');
+  child.Parent = a;
+  const events = [];
+  a.ChildRemoved.Connect(() => events.push('removed'));
+  b.ChildAdded.Connect(() => events.push('added'));
+  child.Parent = b;
+  t.deepEqual(events, ['removed', 'added']);
+});
+
+// AncestryChanged triggers on reparent
+
+test('AncestryChanged triggers', t => {
+  const a = new Instance('A');
+  const child = new Instance('Child');
+  let fired = false;
+  child.AncestryChanged.Connect(() => { fired = true; });
+  child.Parent = a;
+  t.true(fired);
+});
+
+// Changed fires when property mutates
+
+test('Changed fires on property set', t => {
+  const inst = new Instance('Thing');
+  let changed = '';
+  inst.Changed.Connect(prop => { changed = prop; });
+  inst.setProperty('Name', 'Other');
+  t.is(changed, 'Name');
+});
+
+// Attributes roundtrip
+
+test('Attributes set/get roundtrip', t => {
+  const inst = new Instance('Thing');
+  inst.SetAttribute('Health', 100);
+  t.is(inst.GetAttribute('Health'), 100);
+  t.deepEqual(inst.GetAttributes(), { Health: 100 });
+});


### PR DESCRIPTION
## Summary
- add lightweight Signal utility for event connections
- implement Roblox-like Instance tree with ancestry and property change signals
- provide typed Attributes with validators and pre-created Lighting service
- expand tests for signal behavior and attributes

## Testing
- `npm test`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68c49c0257d0832ca8d90ec6563598d8