### PR TITLE
feat: add CollectionService with tagging API

### DIFF
--- a/engine/core/index.js
+++ b/engine/core/index.js
@@ -1,4 +1,5 @@
 import Lighting from '../services/Lighting.js';
+import CollectionService from '../services/CollectionService.js';
 import { Signal } from './signal.js';
 import { isValidAttribute } from './types.js';
 
@@ -108,6 +109,10 @@ const Services = new Map();
 const lighting = new Instance('Lighting');
 Object.assign(lighting, new Lighting());
 Services.set('Lighting', lighting);
+
+const collectionService = new Instance('CollectionService');
+Object.assign(collectionService, new CollectionService());
+Services.set('CollectionService', collectionService);
 
 function GetService(name) {
   return Services.get(name);

--- a/engine/services/CollectionService.js
+++ b/engine/services/CollectionService.js
@@ -1,0 +1,84 @@
+import { Signal } from '../core/signal.js';
+
+export default class CollectionService {
+  constructor() {
+    this.tagMap = new Map(); // tag -> Set(instances)
+    this.addedSignals = new Map();
+    this.removedSignals = new Map();
+
+    this._getTagSet = tag => {
+      if (!this.tagMap.has(tag)) {
+        this.tagMap.set(tag, new Set());
+      }
+      return this.tagMap.get(tag);
+    };
+
+    this._getSignal = (map, tag) => {
+      if (!map.has(tag)) {
+        map.set(tag, new Signal());
+      }
+      return map.get(tag);
+    };
+
+    this.AddTag = (instance, tag) => {
+      if (!instance.__collectionTags) {
+        instance.__collectionTags = new Set();
+        instance.__collectionConnection = instance.AncestryChanged.Connect((inst, parent) => {
+          if (parent === null) {
+            for (const t of [...instance.__collectionTags]) {
+              this.RemoveTag(instance, t);
+            }
+          }
+        });
+      }
+      if (instance.__collectionTags.has(tag)) return;
+
+      instance.__collectionTags.add(tag);
+      this._getTagSet(tag).add(instance);
+      const added = this.addedSignals.get(tag);
+      if (added) added.Fire(instance);
+    };
+
+    this.RemoveTag = (instance, tag) => {
+      if (!instance.__collectionTags || !instance.__collectionTags.has(tag)) return;
+
+      instance.__collectionTags.delete(tag);
+      const tagSet = this.tagMap.get(tag);
+      if (tagSet) {
+        tagSet.delete(instance);
+        if (tagSet.size === 0) this.tagMap.delete(tag);
+      }
+      const removed = this.removedSignals.get(tag);
+      if (removed) removed.Fire(instance);
+
+      if (instance.__collectionTags.size === 0) {
+        if (instance.__collectionConnection) {
+          instance.__collectionConnection.Disconnect();
+        }
+        delete instance.__collectionTags;
+        delete instance.__collectionConnection;
+      }
+    };
+
+    this.HasTag = (instance, tag) => {
+      return !!(instance.__collectionTags && instance.__collectionTags.has(tag));
+    };
+
+    this.GetTags = instance => {
+      return instance.__collectionTags ? Array.from(instance.__collectionTags) : [];
+    };
+
+    this.GetTagged = tag => {
+      const tagSet = this.tagMap.get(tag);
+      return tagSet ? Array.from(tagSet) : [];
+    };
+
+    this.GetInstanceAddedSignal = tag => {
+      return this._getSignal(this.addedSignals, tag);
+    };
+
+    this.GetInstanceRemovedSignal = tag => {
+      return this._getSignal(this.removedSignals, tag);
+    };
+  }
+}

--- a/tests/ava/collectionservice.test.js
+++ b/tests/ava/collectionservice.test.js
@@ -1,0 +1,56 @@
+import test from 'ava';
+import { Instance, GetService } from '../../engine/core/index.js';
+
+const CS = () => GetService('CollectionService');
+
+// Add/remove tags; query correctness
+
+test('add/remove tags and query', t => {
+  const cs = CS();
+  const inst = new Instance('Thing');
+  cs.AddTag(inst, 'Tag');
+  t.true(cs.HasTag(inst, 'Tag'));
+  t.deepEqual(cs.GetTags(inst), ['Tag']);
+  t.deepEqual(cs.GetTagged('Tag'), [inst]);
+  cs.RemoveTag(inst, 'Tag');
+  t.false(cs.HasTag(inst, 'Tag'));
+  t.deepEqual(cs.GetTags(inst), []);
+  t.deepEqual(cs.GetTagged('Tag'), []);
+});
+
+// Signals fire on add/remove
+
+test('signals fire on add/remove', t => {
+  const cs = CS();
+  const inst = new Instance('Part');
+  let added = false;
+  let removed = false;
+  cs.GetInstanceAddedSignal('A').Once(i => {
+    if (i === inst) added = true;
+  });
+  cs.GetInstanceRemovedSignal('A').Once(i => {
+    if (i === inst) removed = true;
+  });
+  cs.AddTag(inst, 'A');
+  cs.RemoveTag(inst, 'A');
+  t.true(added);
+  t.true(removed);
+});
+
+// Instances removed -> no stale refs
+
+test('instances removed cleanup tags', t => {
+  const cs = CS();
+  const parent = new Instance('Parent');
+  const child = new Instance('Child');
+  child.Parent = parent;
+  let removed = false;
+  cs.GetInstanceRemovedSignal('Gone').Once(i => {
+    if (i === child) removed = true;
+  });
+  cs.AddTag(child, 'Gone');
+  child.Remove();
+  t.true(removed);
+  t.deepEqual(cs.GetTagged('Gone'), []);
+  t.false(cs.HasTag(child, 'Gone'));
+});


### PR DESCRIPTION
## Summary
- add CollectionService to tag Instances and query by tag
- register CollectionService in core services map
- test CollectionService for tag operations and cleanup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4c12fa908832c8e682ee2eb28d2e5