### PR TITLE
feat: add TweenService

### DIFF
--- a/engine/core/index.js
+++ b/engine/core/index.js
@@ -1,5 +1,6 @@
 import Lighting from '../services/Lighting.js';
 import CollectionService from '../services/CollectionService.js';
+import TweenService from '../services/TweenService.js';
 import { Signal } from './signal.js';
 import { isValidAttribute } from './types.js';
 
@@ -113,6 +114,10 @@ Services.set('Lighting', lighting);
 const collectionService = new Instance('CollectionService');
 Object.assign(collectionService, new CollectionService());
 Services.set('CollectionService', collectionService);
+
+const tweenService = new Instance('TweenService');
+Object.assign(tweenService, new TweenService());
+Services.set('TweenService', tweenService);
 
 function GetService(name) {
   return Services.get(name);

--- a/engine/services/TweenService.js
+++ b/engine/services/TweenService.js
@@ -1,0 +1,125 @@
+import { Signal } from '../core/signal.js';
+import { applyEasing } from './easing.js';
+
+const now = () => (typeof performance !== 'undefined' && performance.now ? performance.now() : Date.now());
+const raf = globalThis.requestAnimationFrame || (cb => setTimeout(() => cb(now()), 16));
+const caf = globalThis.cancelAnimationFrame || clearTimeout;
+
+class Tween {
+  constructor(instance, info, goals) {
+    this.Instance = instance;
+    this.Info = {
+      Time: info.Time,
+      EasingStyle: info.EasingStyle || 'Linear',
+      EasingDirection: info.EasingDirection || 'In',
+      DelayTime: info.DelayTime || 0,
+      RepeatCount: info.RepeatCount || 0,
+      Reverses: info.Reverses || false,
+    };
+    this.PropertyGoals = {};
+    this._initial = {};
+    for (const [prop, goal] of Object.entries(goals)) {
+      const start = instance[prop];
+      if (typeof start === 'number' && typeof goal === 'number') {
+        this._initial[prop] = start;
+        this.PropertyGoals[prop] = goal;
+      }
+    }
+    this.Completed = new Signal();
+    this.State = 'Idle';
+    this._rafId = null;
+    this._startTime = null;
+    this._elapsed = 0;
+    this._remaining = this.Info.RepeatCount;
+    this._directionForward = true;
+  }
+
+  _schedule() {
+    this._rafId = raf(ts => this._update(ts));
+  }
+
+  Play() {
+    if (this.State === 'playing') return;
+    if (this._rafId) caf(this._rafId);
+    this.State = 'playing';
+    this._startTime = null;
+    this._elapsed = 0;
+    this._remaining = this.Info.RepeatCount;
+    this._directionForward = true;
+    for (const prop in this._initial) {
+      this.Instance.setProperty(prop, this._initial[prop]);
+    }
+    this._schedule();
+  }
+
+  Pause() {
+    if (this.State !== 'playing') return;
+    this.State = 'paused';
+    if (this._rafId) {
+      caf(this._rafId);
+      this._rafId = null;
+    }
+    this._elapsed = now() - this._startTime;
+  }
+
+  Resume() {
+    if (this.State !== 'paused') return;
+    this.State = 'playing';
+    this._startTime = now() - this._elapsed;
+    this._schedule();
+  }
+
+  Cancel() {
+    if (this._rafId) {
+      caf(this._rafId);
+      this._rafId = null;
+    }
+    this.State = 'canceled';
+    for (const prop in this._initial) {
+      this.Instance.setProperty(prop, this._initial[prop]);
+    }
+  }
+
+  _update(timestamp) {
+    if (this.State !== 'playing') return;
+    if (this._startTime === null) {
+      this._startTime = timestamp + this.Info.DelayTime * 1000;
+    }
+    const elapsed = timestamp - this._startTime;
+    if (elapsed < 0) {
+      this._schedule();
+      return;
+    }
+    this._elapsed = elapsed;
+    const duration = this.Info.Time * 1000;
+    let progress = Math.min(elapsed / duration, 1);
+    const eased = applyEasing(this.Info.EasingStyle, this.Info.EasingDirection, progress);
+    for (const prop in this.PropertyGoals) {
+      const start = this._directionForward ? this._initial[prop] : this.PropertyGoals[prop];
+      const end = this._directionForward ? this.PropertyGoals[prop] : this._initial[prop];
+      const value = start + (end - start) * eased;
+      this.Instance.setProperty(prop, value);
+    }
+    if (progress < 1) {
+      this._schedule();
+    } else {
+      if (this._remaining === -1 || this._remaining > 0) {
+        if (this._remaining > 0) this._remaining--;
+        if (this.Info.Reverses) this._directionForward = !this._directionForward;
+        this._startTime = timestamp;
+        this._elapsed = 0;
+        this._schedule();
+      } else {
+        this.State = 'completed';
+        this.Completed.Fire(this);
+      }
+    }
+  }
+}
+
+export default class TweenService {
+  constructor() {
+    this.Create = (instance, info, goals) => new Tween(instance, info, goals);
+  }
+}
+

--- a/engine/services/easing.js
+++ b/engine/services/easing.js
@@ -1,0 +1,78 @@
+const { PI, sin, cos, pow } = Math;
+
+function bounceOut(t) {
+  const n1 = 7.5625;
+  const d1 = 2.75;
+  if (t < 1 / d1) {
+    return n1 * t * t;
+  } else if (t < 2 / d1) {
+    t -= 1.5 / d1;
+    return n1 * t * t + 0.75;
+  } else if (t < 2.5 / d1) {
+    t -= 2.25 / d1;
+    return n1 * t * t + 0.9375;
+  } else {
+    t -= 2.625 / d1;
+    return n1 * t * t + 0.984375;
+  }
+}
+
+function elasticIn(t) {
+  if (t === 0 || t === 1) return t;
+  return -pow(2, 10 * t - 10) * sin((t * 10 - 10.75) * ((2 * PI) / 3));
+}
+
+function elasticOut(t) {
+  if (t === 0 || t === 1) return t;
+  return pow(2, -10 * t) * sin((t * 10 - 0.75) * ((2 * PI) / 3)) + 1;
+}
+
+function elasticInOut(t) {
+  if (t === 0 || t === 1) return t;
+  if (t < 0.5) {
+    return -(pow(2, 20 * t - 10) * sin((20 * t - 11.125) * ((2 * PI) / 4.5))) / 2;
+  }
+  return (
+    pow(2, -20 * t + 10) * sin((20 * t - 11.125) * ((2 * PI) / 4.5)) / 2 +
+    1
+  );
+}
+
+export function applyEasing(style = 'Linear', direction = 'In', t) {
+  if (style === 'Bounce') {
+    if (direction === 'In') return 1 - bounceOut(1 - t);
+    if (direction === 'Out') return bounceOut(t);
+    if (t < 0.5) {
+      return (1 - bounceOut(1 - 2 * t)) / 2;
+    }
+    return (1 + bounceOut(2 * t - 1)) / 2;
+  }
+
+  if (style === 'Elastic') {
+    if (direction === 'In') return elasticIn(t);
+    if (direction === 'Out') return elasticOut(t);
+    return elasticInOut(t);
+  }
+
+  const base = {
+    Linear: v => v,
+    Quad: v => v * v,
+    Cubic: v => v * v * v,
+    Quart: v => v * v * v * v,
+    Quint: v => v * v * v * v * v,
+    Sine: v => 1 - cos((v * PI) / 2),
+    Expo: v => (v === 0 ? 0 : pow(2, 10 * v - 10)),
+  }[style] || (v => v);
+
+  if (direction === 'Out') {
+    return 1 - base(1 - t);
+  }
+  if (direction === 'InOut') {
+    if (t < 0.5) {
+      return base(t * 2) / 2;
+    }
+    return 1 - base(2 - 2 * t) / 2;
+  }
+  return base(t);
+}
+

--- a/tests/ava/tweenservice.test.js
+++ b/tests/ava/tweenservice.test.js
@@ -1,0 +1,55 @@
+import test from 'ava';
+import { Instance, GetService } from '../../engine/core/index.js';
+
+const TS = () => GetService('TweenService');
+
+// Linear tween from 0 to 10
+
+test('linear tween 0->10', async t => {
+  const inst = new Instance('Thing');
+  inst.setProperty('Value', 0);
+  const tween = TS().Create(inst, { Time: 0.1, EasingStyle: 'Linear', EasingDirection: 'In' }, { Value: 10 });
+  tween.Play();
+  await tween.Completed.Wait();
+  t.is(inst.Value, 10);
+});
+
+// Delay + repeat + reverse
+
+test('delay repeat reverse', async t => {
+  const inst = new Instance('Thing');
+  inst.setProperty('Value', 0);
+  let firstChange = null;
+  let max = 0;
+  inst.Changed.Connect(prop => {
+    if (prop === 'Value') {
+      if (firstChange === null) firstChange = Date.now();
+      if (inst.Value > max) max = inst.Value;
+    }
+  });
+  const start = Date.now();
+  const tween = TS().Create(
+    inst,
+    { Time: 0.05, EasingStyle: 'Linear', EasingDirection: 'In', DelayTime: 0.05, RepeatCount: 1, Reverses: true },
+    { Value: 10 }
+  );
+  tween.Play();
+  await tween.Completed.Wait();
+  t.true(firstChange - start >= 50);
+  t.is(inst.Value, 0);
+  t.is(Math.round(max), 10);
+});
+
+// Completed fires once
+
+test('completed fires once', async t => {
+  const inst = new Instance('Thing');
+  inst.setProperty('Value', 0);
+  const tween = TS().Create(inst, { Time: 0.05, EasingStyle: 'Linear', EasingDirection: 'In', RepeatCount: 2 }, { Value: 5 });
+  let count = 0;
+  tween.Completed.Connect(() => { count++; });
+  tween.Play();
+  await tween.Completed.Wait();
+  t.is(count, 1);
+});
+


### PR DESCRIPTION
## Summary
- add easing helpers with common easing styles and directions
- implement TweenService to tween numeric properties with play, pause, resume and cancel controls
- register TweenService and cover core tween behaviors with AVA tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4c800cb98832cbcbbfd614d54aa8f