### PR TITLE
Implement scene graph serialization and undo/redo service

### DIFF
--- a/editor/panes/explorer.js
+++ b/editor/panes/explorer.js
@@ -1,5 +1,25 @@
+import { Instance } from '../../engine/core/index.js';
+import UndoService from '../services/undo.js';
+import SelectionService from '../services/selection.js';
+
+// Minimal Explorer pane logic providing creation and deletion actions
+// hooked into the undo service.
 export default class Explorer {
-  constructor() {
-    // stub for explorer pane
+  constructor(undo = new UndoService(), selection = new SelectionService()) {
+    this.undo = undo;
+    this.selection = selection;
+  }
+
+  addModel() {
+    const model = new Instance('Model');
+    this.undo.execute(this.undo.createInstance(model, null));
+    return model;
+  }
+
+  deleteSelected() {
+    for (const inst of this.selection.getSelection()) {
+      this.undo.execute(this.undo.deleteInstance(inst));
+    }
+    this.selection.clear();
   }
 }

--- a/editor/panes/properties.js
+++ b/editor/panes/properties.js
@@ -1,5 +1,14 @@
+import UndoService from '../services/undo.js';
+
+// Minimal properties pane. Editing a numeric property pushes an undo entry.
 export default class Properties {
-  constructor() {
-    // stub for properties pane
+  constructor(undo = new UndoService()) {
+    this.undo = undo;
+  }
+
+  editNumber(inst, prop, value) {
+    const num = Number(value);
+    if (Number.isNaN(num)) return;
+    this.undo.execute(this.undo.setProperty(inst, prop, num));
   }
 }

--- a/editor/services/selection.js
+++ b/editor/services/selection.js
@@ -1,0 +1,38 @@
+import { Signal } from '../../engine/core/signal.js';
+
+// Basic selection service used by the editor. Keeps a list of selected
+// Instances and emits a signal when the selection changes.
+export default class SelectionService {
+  constructor() {
+    this.selection = [];
+    this.SelectionChanged = new Signal();
+  }
+
+  getSelection() {
+    return [...this.selection];
+  }
+
+  setSelection(items) {
+    this.selection = [...items];
+    this.SelectionChanged.Fire(this.getSelection());
+  }
+
+  clear() {
+    this.setSelection([]);
+  }
+
+  add(item) {
+    if (!this.selection.includes(item)) {
+      this.selection.push(item);
+      this.SelectionChanged.Fire(this.getSelection());
+    }
+  }
+
+  remove(item) {
+    const idx = this.selection.indexOf(item);
+    if (idx !== -1) {
+      this.selection.splice(idx, 1);
+      this.SelectionChanged.Fire(this.getSelection());
+    }
+  }
+}

--- a/editor/services/undo.js
+++ b/editor/services/undo.js
@@ -1,0 +1,93 @@
+// Simple undo/redo stack for editor actions.
+export default class UndoService {
+  constructor() {
+    this.undoStack = [];
+    this.redoStack = [];
+  }
+
+  // Execute a command and push it onto the undo stack.
+  execute(cmd) {
+    if (cmd && typeof cmd.redo === 'function') {
+      cmd.redo();
+      this.undoStack.push(cmd);
+      this.redoStack.length = 0;
+    }
+  }
+
+  undo() {
+    const cmd = this.undoStack.pop();
+    if (cmd && typeof cmd.undo === 'function') {
+      cmd.undo();
+      this.redoStack.push(cmd);
+    }
+  }
+
+  redo() {
+    const cmd = this.redoStack.pop();
+    if (cmd && typeof cmd.redo === 'function') {
+      cmd.redo();
+      this.undoStack.push(cmd);
+    }
+  }
+
+  // Command helpers
+  createInstance(inst, parent) {
+    return {
+      undo() {
+        inst.Parent = null;
+      },
+      redo() {
+        inst.Parent = parent;
+      },
+    };
+  }
+
+  deleteInstance(inst) {
+    const parent = inst.Parent;
+    return {
+      undo() {
+        inst.Parent = parent;
+      },
+      redo() {
+        inst.Parent = null;
+      },
+    };
+  }
+
+  reparent(inst, newParent) {
+    const oldParent = inst.Parent;
+    return {
+      undo() {
+        inst.Parent = oldParent;
+      },
+      redo() {
+        inst.Parent = newParent;
+      },
+    };
+  }
+
+  setProperty(inst, prop, value) {
+    const oldValue = inst[prop];
+    return {
+      undo() {
+        inst.setProperty(prop, oldValue);
+      },
+      redo() {
+        inst.setProperty(prop, value);
+      },
+    };
+  }
+
+  setAttribute(inst, attr, value) {
+    const oldValue = inst.GetAttribute(attr);
+    return {
+      undo() {
+        if (oldValue === undefined) inst.Attributes.delete(attr);
+        else inst.SetAttribute(attr, oldValue);
+      },
+      redo() {
+        inst.SetAttribute(attr, value);
+      },
+    };
+  }
+}

--- a/engine/scene/deserialize.js
+++ b/engine/scene/deserialize.js
@@ -1,0 +1,36 @@
+import { Instance, GetService } from '../core/index.js';
+
+// Deserialize a JSON string produced by serialize() back into an Instance
+// hierarchy. Service instances are reused if they already exist.
+export function deserialize(json) {
+  const data = typeof json === 'string' ? JSON.parse(json) : json;
+
+  function build(node) {
+    // Reuse existing service instances when available
+    let inst = GetService(node.className);
+    if (!inst) {
+      inst = new Instance(node.className);
+    }
+    inst.guid = node.guid;
+    inst.Name = node.name;
+
+    for (const [k, v] of Object.entries(node.properties || {})) {
+      inst.setProperty(k, v);
+    }
+    for (const [k, v] of Object.entries(node.attributes || {})) {
+      inst.SetAttribute(k, v);
+    }
+
+    // Clear existing children before reconstructing
+    inst.ClearAllChildren();
+    for (const child of node.children || []) {
+      const childInst = build(child);
+      childInst.Parent = inst;
+    }
+    return inst;
+  }
+
+  return build(data);
+}
+
+export default deserialize;

--- a/engine/scene/guid.js
+++ b/engine/scene/guid.js
@@ -1,0 +1,10 @@
+import { randomUUID } from 'node:crypto';
+
+// Generate a stable GUID for scene nodes. Uses Node's crypto API to
+// produce a UUID v4 string. Keeping this in a module allows swapping
+// implementations later without touching callers.
+export function guid() {
+  return randomUUID();
+}
+
+export default guid;

--- a/engine/scene/serialize.js
+++ b/engine/scene/serialize.js
@@ -1,0 +1,44 @@
+import guid from './guid.js';
+import { Signal } from '../core/signal.js';
+
+// Serialize an Instance hierarchy to JSON.
+// Only serializes own enumerable properties (excluding engine internals),
+// attributes and child relationships. Each node receives a stable GUID.
+export function serialize(root) {
+  function serializeInst(inst) {
+    if (!inst.guid) inst.guid = guid();
+
+    const node = {
+      guid: inst.guid,
+      className: inst.ClassName,
+      name: inst.Name,
+      properties: {},
+      attributes: inst.GetAttributes(),
+      children: [],
+    };
+
+    for (const [k, v] of Object.entries(inst)) {
+      if (!Object.prototype.hasOwnProperty.call(inst, k)) continue;
+      if (
+        k === 'ClassName' ||
+        k === 'Name' ||
+        k === 'Children' ||
+        k === 'Attributes' ||
+        k === '_parent' ||
+        k === 'guid'
+      )
+        continue;
+      if (v instanceof Signal) continue;
+      if (typeof v === 'function') continue;
+      node.properties[k] = v;
+    }
+
+    node.children = inst.Children.map(serializeInst);
+    return node;
+  }
+
+  const data = serializeInst(root);
+  return JSON.stringify(data);
+}
+
+export default serialize;

--- a/tests/ava/scene-io.test.js
+++ b/tests/ava/scene-io.test.js
@@ -1,0 +1,27 @@
+import test from 'ava';
+import { Instance } from '../../engine/core/index.js';
+import { serialize } from '../../engine/scene/serialize.js';
+import { deserialize } from '../../engine/scene/deserialize.js';
+
+// Ensure scene graphs roundtrip through JSON serialization.
+test('scene serialize/deserialize roundtrip', t => {
+  const root = new Instance('Model');
+  root.Name = 'Root';
+  const child = new Instance('Part');
+  child.Name = 'Child';
+  child.setProperty('Value', 10);
+  child.SetAttribute('Color', 'red');
+  root.Add(child);
+
+  const json = serialize(root);
+  const clone = deserialize(json);
+
+  t.truthy(clone.guid);
+  t.is(clone.Name, 'Root');
+  t.is(clone.Children.length, 1);
+  const newChild = clone.Children[0];
+  t.is(newChild.Name, 'Child');
+  t.is(newChild.Value, 10);
+  t.is(newChild.GetAttribute('Color'), 'red');
+  t.is(newChild.Parent, clone);
+});

--- a/tests/ava/undo.test.js
+++ b/tests/ava/undo.test.js
@@ -1,0 +1,34 @@
+import test from 'ava';
+import { Instance } from '../../engine/core/index.js';
+import UndoService from '../../editor/services/undo.js';
+
+// Basic undo/redo command stack functionality
+test('create/delete instance undo', t => {
+  const undo = new UndoService();
+  const parent = new Instance('Model');
+  const child = new Instance('Part');
+
+  undo.execute(undo.createInstance(child, parent));
+  t.is(child.Parent, parent);
+
+  undo.undo();
+  t.is(child.Parent, null);
+
+  undo.redo();
+  t.is(child.Parent, parent);
+});
+
+test('property change undo', t => {
+  const undo = new UndoService();
+  const inst = new Instance('Part');
+  inst.setProperty('Value', 1);
+
+  undo.execute(undo.setProperty(inst, 'Value', 2));
+  t.is(inst.Value, 2);
+
+  undo.undo();
+  t.is(inst.Value, 1);
+
+  undo.redo();
+  t.is(inst.Value, 2);
+});


### PR DESCRIPTION
## Summary
- Add deterministic GUID helper and scene serialize/deserialize utilities
- Provide editor undo/redo stack with selection service and explorer/properties hooks
- Test scene IO roundtrip and undo stack behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4e43118d0832cb7ba31cf826bf750