### PR TITLE
Add skeleton PBR material registry

### DIFF
--- a/engine/render/gpu/webgpu.js
+++ b/engine/render/gpu/webgpu.js
@@ -3,6 +3,7 @@ import FrameGraph from '../framegraph/index.js';
 import ClearPass from '../passes/clearPass.js';
 import SkyPass from '../passes/skyPass.js';
 import MeshPass from '../passes/meshPass.js';
+import Materials from '../materials/registry.js';
 
 export async function initWebGPU(canvas) {
   if (!navigator.gpu) {
@@ -14,6 +15,8 @@ export async function initWebGPU(canvas) {
   const context = canvas.getContext('webgpu');
   const format = navigator.gpu.getPreferredCanvasFormat();
   context.configure({ device, format });
+
+  Materials.init(device);
 
   const frameGraph = new FrameGraph(device, context);
   frameGraph.addPass(new ClearPass(device));

--- a/engine/render/materials/material.js
+++ b/engine/render/materials/material.js
@@ -1,0 +1,88 @@
+const DEFAULT_COLOR = [1, 1, 1, 1];
+const DEFAULT_ROUGHNESS = 1.0;
+const DEFAULT_METALNESS = 0.0;
+
+function toVec4Color(input) {
+  if (!input) {
+    return new Float32Array(DEFAULT_COLOR);
+  }
+
+  const arr = Array.from(input);
+  if (arr.length === 3) {
+    arr.push(1.0);
+  }
+  if (arr.length !== 4) {
+    throw new Error('Color values must have 3 or 4 components.');
+  }
+  return new Float32Array(arr);
+}
+
+export class StandardPBRMaterial {
+  constructor(params = {}) {
+    this.type = 'StandardPBR';
+    this.color = toVec4Color(params.color);
+    this.roughness = params.roughness ?? DEFAULT_ROUGHNESS;
+    this.metalness = params.metalness ?? DEFAULT_METALNESS;
+
+    this.maps = {
+      albedo: { texture: null, sampler: null },
+      normal: { texture: null, sampler: null },
+      orm: { texture: null, sampler: null }
+    };
+
+    this.update(params);
+  }
+
+  update(params = {}) {
+    if (Object.prototype.hasOwnProperty.call(params, 'color')) {
+      this.color = toVec4Color(params.color);
+    }
+    if (Object.prototype.hasOwnProperty.call(params, 'roughness') && typeof params.roughness === 'number') {
+      this.roughness = params.roughness;
+    }
+    if (Object.prototype.hasOwnProperty.call(params, 'metalness') && typeof params.metalness === 'number') {
+      this.metalness = params.metalness;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(params, 'albedoTexture')) {
+      this.maps.albedo.texture = params.albedoTexture;
+    }
+    if (Object.prototype.hasOwnProperty.call(params, 'albedoSampler')) {
+      this.maps.albedo.sampler = params.albedoSampler;
+    }
+    if (Object.prototype.hasOwnProperty.call(params, 'normalTexture')) {
+      this.maps.normal.texture = params.normalTexture;
+    }
+    if (Object.prototype.hasOwnProperty.call(params, 'normalSampler')) {
+      this.maps.normal.sampler = params.normalSampler;
+    }
+    if (Object.prototype.hasOwnProperty.call(params, 'ormTexture')) {
+      this.maps.orm.texture = params.ormTexture;
+    }
+    if (Object.prototype.hasOwnProperty.call(params, 'ormSampler')) {
+      this.maps.orm.sampler = params.ormSampler;
+    }
+  }
+
+  toUniformArray(target) {
+    const out = target || new Float32Array(8);
+    out.set(this.color, 0);
+    out[4] = this.roughness;
+    out[5] = this.metalness;
+    out[6] = 0.0;
+    out[7] = 0.0;
+    return out;
+  }
+}
+
+export const DEFAULT_STANDARD_PBR_PARAMS = {
+  color: DEFAULT_COLOR,
+  roughness: DEFAULT_ROUGHNESS,
+  metalness: DEFAULT_METALNESS,
+  albedoTexture: null,
+  albedoSampler: null,
+  normalTexture: null,
+  normalSampler: null,
+  ormTexture: null,
+  ormSampler: null
+};

--- a/engine/render/materials/registry.js
+++ b/engine/render/materials/registry.js
@@ -1,0 +1,90 @@
+import { StandardPBRMaterial } from './material.js';
+import {
+  allocateStandardPBRUniform,
+  updateStandardPBRUniform,
+  createStandardPBRLayout,
+  describeStandardPBRBindings,
+  createStandardPBRBindGroup
+} from './ubos.js';
+
+class MaterialRegistry {
+  constructor() {
+    this.device = null;
+    this.layouts = new Map();
+    this.materials = new Map();
+    this.nextId = 1;
+  }
+
+  init(device) {
+    if (this.device && this.device !== device) {
+      console.warn('[Materials] Reinitializing registry with a new device. Existing materials will be cleared.');
+      this.materials.clear();
+      this.nextId = 1;
+    }
+    if (!this.device || this.device !== device) {
+      this.device = device;
+      if (device) {
+        this.layouts.set('StandardPBR', createStandardPBRLayout(device));
+      }
+    }
+  }
+
+  _ensureDevice() {
+    if (!this.device) {
+      throw new Error('Materials registry has not been initialized with a GPUDevice. Call Materials.init(device) first.');
+    }
+  }
+
+  _buildStandardBinding(material, uniform) {
+    const layout = this.layouts.get('StandardPBR');
+    const descriptor = describeStandardPBRBindings(material, uniform);
+    const bindGroup = createStandardPBRBindGroup(this.device, layout, descriptor);
+    return { layout, descriptor, bindGroup };
+  }
+
+  _logRecord(action, record) {
+    const { material, binding } = record;
+    const bindingStates = binding.descriptor.entries.map(entry => ({
+      binding: entry.binding,
+      ready: entry.resource !== null
+    }));
+    console.info(`[Materials] ${action} ${material.type} #${record.id}`, {
+      color: Array.from(material.color),
+      roughness: material.roughness,
+      metalness: material.metalness,
+      bindings: bindingStates
+    });
+  }
+
+  createStandard(params = {}) {
+    this._ensureDevice();
+    const material = new StandardPBRMaterial(params);
+    const uniform = allocateStandardPBRUniform(this.device, material);
+    const binding = this._buildStandardBinding(material, uniform);
+    const id = this.nextId++;
+    const record = { id, type: material.type, material, uniform, binding };
+    this.materials.set(id, record);
+    this._logRecord('Created', record);
+    return id;
+  }
+
+  get(id) {
+    return this.materials.get(id) || null;
+  }
+
+  update(id, params = {}) {
+    const record = this.materials.get(id);
+    if (!record) {
+      throw new Error(`Material with id ${id} does not exist.`);
+    }
+    record.material.update(params);
+    updateStandardPBRUniform(this.device, record.uniform, record.material);
+    record.binding = this._buildStandardBinding(record.material, record.uniform);
+    this._logRecord('Updated', record);
+  }
+}
+
+const Materials = new MaterialRegistry();
+
+export default Materials;
+export { MaterialRegistry };

--- a/engine/render/materials/ubos.js
+++ b/engine/render/materials/ubos.js
@@ -1,0 +1,80 @@
+const FLOAT_SIZE = 4;
+const STANDARD_PBR_FLOATS = 8;
+const STANDARD_PBR_BUFFER_SIZE = STANDARD_PBR_FLOATS * FLOAT_SIZE;
+
+export const STANDARD_PBR_BINDINGS = {
+  UNIFORM: 0,
+  ALBEDO_TEXTURE: 1,
+  ALBEDO_SAMPLER: 2,
+  NORMAL_TEXTURE: 3,
+  NORMAL_SAMPLER: 4,
+  ORM_TEXTURE: 5,
+  ORM_SAMPLER: 6
+};
+
+export function createStandardPBRLayout(device) {
+  return device.createBindGroupLayout({
+    label: 'StandardPBRMaterialLayout',
+    entries: [
+      { binding: STANDARD_PBR_BINDINGS.UNIFORM, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, buffer: { type: 'uniform' } },
+      { binding: STANDARD_PBR_BINDINGS.ALBEDO_TEXTURE, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float' } },
+      { binding: STANDARD_PBR_BINDINGS.ALBEDO_SAMPLER, visibility: GPUShaderStage.FRAGMENT, sampler: {} },
+      { binding: STANDARD_PBR_BINDINGS.NORMAL_TEXTURE, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float' } },
+      { binding: STANDARD_PBR_BINDINGS.NORMAL_SAMPLER, visibility: GPUShaderStage.FRAGMENT, sampler: {} },
+      { binding: STANDARD_PBR_BINDINGS.ORM_TEXTURE, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float' } },
+      { binding: STANDARD_PBR_BINDINGS.ORM_SAMPLER, visibility: GPUShaderStage.FRAGMENT, sampler: {} }
+    ]
+  });
+}
+
+export function allocateStandardPBRUniform(device, material) {
+  const data = material.toUniformArray(new Float32Array(STANDARD_PBR_FLOATS));
+  const buffer = device.createBuffer({
+    size: STANDARD_PBR_BUFFER_SIZE,
+    usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    label: 'StandardPBRMaterialUniform'
+  });
+  device.queue.writeBuffer(buffer, 0, data.buffer, data.byteOffset, data.byteLength);
+  return { buffer, data, size: STANDARD_PBR_BUFFER_SIZE };
+}
+
+export function updateStandardPBRUniform(device, uniform, material) {
+  material.toUniformArray(uniform.data);
+  device.queue.writeBuffer(uniform.buffer, 0, uniform.data.buffer, uniform.data.byteOffset, uniform.data.byteLength);
+}
+
+export function describeStandardPBRBindings(material, uniform) {
+  const { albedo, normal, orm } = material.maps;
+  return {
+    label: 'StandardPBRMaterial',
+    entries: [
+      { binding: STANDARD_PBR_BINDINGS.UNIFORM, resource: { buffer: uniform.buffer } },
+      { binding: STANDARD_PBR_BINDINGS.ALBEDO_TEXTURE, resource: albedo.texture ?? null },
+      { binding: STANDARD_PBR_BINDINGS.ALBEDO_SAMPLER, resource: albedo.sampler ?? null },
+      { binding: STANDARD_PBR_BINDINGS.NORMAL_TEXTURE, resource: normal.texture ?? null },
+      { binding: STANDARD_PBR_BINDINGS.NORMAL_SAMPLER, resource: normal.sampler ?? null },
+      { binding: STANDARD_PBR_BINDINGS.ORM_TEXTURE, resource: orm.texture ?? null },
+      { binding: STANDARD_PBR_BINDINGS.ORM_SAMPLER, resource: orm.sampler ?? null }
+    ]
+  };
+}
+
+export function createStandardPBRBindGroup(device, layout, descriptor) {
+  if (!layout) {
+    throw new Error('A bind group layout is required to create a Standard PBR bind group.');
+  }
+  const ready = descriptor.entries.every(entry => entry.resource !== null);
+  if (!ready) {
+    console.debug('[Materials] Standard PBR bind group incomplete, awaiting texture or sampler resources.');
+    return null;
+  }
+  const entries = descriptor.entries.map(entry => ({
+    binding: entry.binding,
+    resource: entry.resource
+  }));
+  return device.createBindGroup({
+    label: descriptor.label,
+    layout,
+    entries
+  });
+}


### PR DESCRIPTION
## Summary
- add a StandardPBR material description that tracks color, roughness, metalness and texture slots
- implement uniform buffer helpers and binding descriptors for StandardPBR materials
- create a registry to manage material instances and initialize it from the WebGPU bootstrap

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd58dede14832c985766a08891eda7