### PR TITLE
Scaffold directional lighting with cascaded shadow data

### DIFF
--- a/engine/render/lighting/csm.js
+++ b/engine/render/lighting/csm.js
@@ -1,0 +1,272 @@
+const DEFAULT_SCENE_BOUNDS = {
+  min: [-50, -10, -50],
+  max: [50, 50, 50],
+};
+
+const WORLD_UP = [0, 1, 0];
+
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+function dot(a, b) {
+  return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
+function cross(a, b) {
+  return [
+    a[1] * b[2] - a[2] * b[1],
+    a[2] * b[0] - a[0] * b[2],
+    a[0] * b[1] - a[1] * b[0],
+  ];
+}
+
+function normalize(vec) {
+  const length = Math.hypot(vec[0], vec[1], vec[2]);
+  if (length === 0) {
+    return [0, 0, 0];
+  }
+  return [vec[0] / length, vec[1] / length, vec[2] / length];
+}
+
+function add(a, b) {
+  return [a[0] + b[0], a[1] + b[1], a[2] + b[2]];
+}
+
+function subtract(a, b) {
+  return [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+}
+
+function scale(vec, s) {
+  return [vec[0] * s, vec[1] * s, vec[2] * s];
+}
+
+function computeCameraBasis(direction, up = WORLD_UP) {
+  const forward = normalize(direction);
+  let right = cross(forward, up);
+  const rightLength = Math.hypot(right[0], right[1], right[2]);
+  if (rightLength < 1e-5) {
+    right = cross(forward, [0, 0, 1]);
+  }
+  right = normalize(right);
+  const realUp = normalize(cross(right, forward));
+  return { forward, right, up: realUp };
+}
+
+function lookAt(eye, target, up) {
+  const zAxis = normalize(subtract(eye, target));
+  let xAxis = cross(up, zAxis);
+  const len = Math.hypot(xAxis[0], xAxis[1], xAxis[2]);
+  if (len < 1e-5) {
+    xAxis = cross([0, 0, 1], zAxis);
+  }
+  xAxis = normalize(xAxis);
+  const yAxis = cross(zAxis, xAxis);
+
+  return [
+    xAxis[0], yAxis[0], zAxis[0], 0,
+    xAxis[1], yAxis[1], zAxis[1], 0,
+    xAxis[2], yAxis[2], zAxis[2], 0,
+    -dot(xAxis, eye), -dot(yAxis, eye), -dot(zAxis, eye), 1,
+  ];
+}
+
+function multiplyMat4(a, b) {
+  const out = new Array(16).fill(0);
+  for (let row = 0; row < 4; row += 1) {
+    for (let col = 0; col < 4; col += 1) {
+      out[row * 4 + col] =
+        a[row * 4 + 0] * b[0 * 4 + col] +
+        a[row * 4 + 1] * b[1 * 4 + col] +
+        a[row * 4 + 2] * b[2 * 4 + col] +
+        a[row * 4 + 3] * b[3 * 4 + col];
+    }
+  }
+  return out;
+}
+
+function transformPoint(mat, point) {
+  const x = point[0];
+  const y = point[1];
+  const z = point[2];
+  const w =
+    mat[3] * x +
+    mat[7] * y +
+    mat[11] * z +
+    mat[15];
+  const nx =
+    mat[0] * x +
+    mat[4] * y +
+    mat[8] * z +
+    mat[12];
+  const ny =
+    mat[1] * x +
+    mat[5] * y +
+    mat[9] * z +
+    mat[13];
+  const nz =
+    mat[2] * x +
+    mat[6] * y +
+    mat[10] * z +
+    mat[14];
+  if (w !== 0 && w !== 1) {
+    return [nx / w, ny / w, nz / w];
+  }
+  return [nx, ny, nz];
+}
+
+function orthographic(left, right, bottom, top, near, far) {
+  const lr = 1 / (left - right);
+  const bt = 1 / (bottom - top);
+  const nf = 1 / (near - far);
+
+  return [
+    -2 * lr, 0, 0, 0,
+    0, -2 * bt, 0, 0,
+    0, 0, 2 * nf, 0,
+    (left + right) * lr, (top + bottom) * bt, (far + near) * nf, 1,
+  ];
+}
+
+function computeCascadeCorners(camera, cascadeNear, cascadeFar) {
+  const { position, direction, up, fov = Math.PI / 3, aspect = 16 / 9 } = camera;
+  const basis = computeCameraBasis(direction, up);
+
+  const corners = [];
+  const nearHeight = Math.tan(fov * 0.5) * cascadeNear;
+  const nearWidth = nearHeight * aspect;
+  const farHeight = Math.tan(fov * 0.5) * cascadeFar;
+  const farWidth = farHeight * aspect;
+
+  const nearCenter = add(position, scale(basis.forward, cascadeNear));
+  const farCenter = add(position, scale(basis.forward, cascadeFar));
+
+  const upNear = scale(basis.up, nearHeight);
+  const rightNear = scale(basis.right, nearWidth);
+  const upFar = scale(basis.up, farHeight);
+  const rightFar = scale(basis.right, farWidth);
+
+  corners.push(add(add(nearCenter, upNear), rightNear));
+  corners.push(add(subtract(nearCenter, rightNear), upNear));
+  corners.push(subtract(subtract(nearCenter, upNear), rightNear));
+  corners.push(add(subtract(nearCenter, upNear), rightNear));
+
+  corners.push(add(add(farCenter, upFar), rightFar));
+  corners.push(add(subtract(farCenter, rightFar), upFar));
+  corners.push(subtract(subtract(farCenter, upFar), rightFar));
+  corners.push(add(subtract(farCenter, upFar), rightFar));
+
+  return corners;
+}
+
+function computeBoundingSphere(points) {
+  const center = [0, 0, 0];
+  for (const point of points) {
+    center[0] += point[0];
+    center[1] += point[1];
+    center[2] += point[2];
+  }
+  center[0] /= points.length;
+  center[1] /= points.length;
+  center[2] /= points.length;
+
+  let radius = 0;
+  for (const point of points) {
+    const dx = point[0] - center[0];
+    const dy = point[1] - center[1];
+    const dz = point[2] - center[2];
+    const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    radius = Math.max(radius, dist);
+  }
+
+  return { center, radius };
+}
+
+function padCascadeWithSceneBounds(points) {
+  const padded = [...points];
+  const { min, max } = DEFAULT_SCENE_BOUNDS;
+  padded.push([min[0], min[1], min[2]]);
+  padded.push([max[0], max[1], max[2]]);
+  return padded;
+}
+
+export default class CascadedShadowMaps {
+  constructor({ cascades = 4, lambda = 0.5 } = {}) {
+    this.cascades = Math.min(Math.max(cascades, 1), 4);
+    this.lambda = lambda;
+    this.cascadeData = [];
+  }
+
+  computeSplits(near, far) {
+    const splits = [];
+    for (let i = 1; i <= this.cascades; i += 1) {
+      const id = i / this.cascades;
+      const log = near * (far / near) ** id;
+      const uniform = near + (far - near) * id;
+      const split = lerp(uniform, log, this.lambda);
+      splits.push(split);
+    }
+    return splits;
+  }
+
+  update(camera, lightDirection) {
+    const near = camera.near ?? 0.1;
+    const far = camera.far ?? 200;
+    const splits = this.computeSplits(near, far);
+
+    const cascades = [];
+    let lastSplit = near;
+
+    for (let i = 0; i < this.cascades; i += 1) {
+      const cascadeFar = splits[i];
+      const corners = computeCascadeCorners(camera, lastSplit, cascadeFar);
+      const paddedCorners = padCascadeWithSceneBounds(corners);
+      const { center, radius } = computeBoundingSphere(paddedCorners);
+      const lightDir = normalize(lightDirection);
+      const lightPos = subtract(center, scale(lightDir, radius * 2));
+
+      let lightUp = [...WORLD_UP];
+      if (Math.abs(dot(lightUp, lightDir)) > 0.99) {
+        lightUp = [1, 0, 0];
+      }
+
+      const viewMatrix = lookAt(lightPos, center, lightUp);
+      const lightSpaceCorners = paddedCorners.map(point => transformPoint(viewMatrix, point));
+
+      let minX = Infinity;
+      let maxX = -Infinity;
+      let minY = Infinity;
+      let maxY = -Infinity;
+      let minZ = Infinity;
+      let maxZ = -Infinity;
+
+      for (const point of lightSpaceCorners) {
+        minX = Math.min(minX, point[0]);
+        maxX = Math.max(maxX, point[0]);
+        minY = Math.min(minY, point[1]);
+        maxY = Math.max(maxY, point[1]);
+        minZ = Math.min(minZ, point[2]);
+        maxZ = Math.max(maxZ, point[2]);
+      }
+
+      const projectionMatrix = orthographic(minX, maxX, minY, maxY, minZ, maxZ);
+      const viewProjectionMatrix = multiplyMat4(projectionMatrix, viewMatrix);
+
+      cascades.push({
+        index: i,
+        near: lastSplit,
+        far: cascadeFar,
+        viewMatrix,
+        projectionMatrix,
+        viewProjectionMatrix,
+        center,
+        radius,
+      });
+
+      lastSplit = cascadeFar;
+    }
+
+    this.cascadeData = cascades;
+    return cascades;
+  }
+}

--- a/engine/render/lighting/directional.js
+++ b/engine/render/lighting/directional.js
@@ -1,0 +1,67 @@
+import CascadedShadowMaps from './csm.js';
+
+const DEFAULT_DIRECTION = [0, -1, 0];
+const DEFAULT_COLOR = [1, 0.956, 0.839];
+const DEFAULT_INTENSITY = 3.5;
+
+function normalize(vec) {
+  const length = Math.hypot(vec[0], vec[1], vec[2]);
+  if (length === 0) {
+    return [...DEFAULT_DIRECTION];
+  }
+  return [vec[0] / length, vec[1] / length, vec[2] / length];
+}
+
+export default class DirectionalLight {
+  constructor({
+    direction = DEFAULT_DIRECTION,
+    color = DEFAULT_COLOR,
+    intensity = DEFAULT_INTENSITY,
+    cascades = 4,
+  } = {}) {
+    this.direction = normalize(direction);
+    this.color = [...color];
+    this.intensity = intensity;
+
+    this.csm = new CascadedShadowMaps({ cascades });
+  }
+
+  setDirection(vec) {
+    this.direction = normalize(vec);
+  }
+
+  setColor(color) {
+    this.color = [...color];
+  }
+
+  setIntensity(value) {
+    this.intensity = value;
+  }
+
+  update(camera) {
+    if (!camera) {
+      return;
+    }
+
+    const cascadeData = this.csm.update(camera, this.direction);
+
+    cascadeData.forEach((cascade, index) => {
+      console.log(
+        `DirectionalLight CSM Cascade ${index}: split [${cascade.near.toFixed(3)}, ${cascade.far.toFixed(3)}]`
+      );
+      console.log('  View Matrix:', cascade.viewMatrix);
+      console.log('  Projection Matrix:', cascade.projectionMatrix);
+      console.log('  ViewProjection Matrix:', cascade.viewProjectionMatrix);
+    });
+  }
+
+  getSunParams() {
+    return {
+      direction: [...this.direction],
+      color: [...this.color],
+      intensity: this.intensity,
+      cascades: this.csm.cascades,
+      cascadeData: this.csm.cascadeData,
+    };
+  }
+}

--- a/engine/services/Lighting.js
+++ b/engine/services/Lighting.js
@@ -1,5 +1,56 @@
+import DirectionalLight from '../render/lighting/directional.js';
+
+function defaultCameraState() {
+  return {
+    position: [0, 15, 35],
+    direction: [0, -0.35, -1],
+    up: [0, 1, 0],
+    near: 0.1,
+    far: 150,
+    fov: Math.PI / 3,
+    aspect: 16 / 9,
+  };
+}
+
 export default class Lighting {
   constructor() {
     this.enabled = true;
+    this.sun = new DirectionalLight();
+    this._camera = defaultCameraState();
+  }
+
+  setEnabled(enabled) {
+    this.enabled = Boolean(enabled);
+  }
+
+  setSunDirection(direction) {
+    this.sun.setDirection(direction);
+  }
+
+  setSunColor(color) {
+    this.sun.setColor(color);
+  }
+
+  setSunIntensity(intensity) {
+    this.sun.setIntensity(intensity);
+  }
+
+  setCameraState(camera) {
+    this._camera = {
+      ...this._camera,
+      ...camera,
+    };
+  }
+
+  update() {
+    if (!this.enabled) {
+      return;
+    }
+
+    this.sun.update(this._camera);
+  }
+
+  getSun() {
+    return this.sun.getSunParams();
   }
 }


### PR DESCRIPTION
## Summary
- add a directional light implementation that normalizes sun parameters and computes cascaded shadow map data
- implement a cascaded shadow map helper that calculates practical split distances and light matrices against a stub scene bounds
- extend the Lighting service with sun configuration APIs, default camera state, and an update hook that refreshes cascade matrices

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd5b587c00832c9046975c9fa55c80