### PR TITLE
Add HDR post-processing pipeline with ACES tonemap and FXAA

### DIFF
--- a/editor/app/main.js
+++ b/editor/app/main.js
@@ -4,6 +4,7 @@ import ConsolePane from '../panes/console.js';
 import GitPane from '../panes/git.js';
 import { initViewport } from '../services/viewport.js';
 import { checkForUpdates } from '../services/update-checker.js';
+import SettingsPane from '../panes/settings.js';
 
 export function bootstrap() {
   new Explorer();
@@ -11,6 +12,7 @@ export function bootstrap() {
   initViewport();
   new ConsolePane();
   new GitPane();
+  new SettingsPane();
   checkForUpdates();
 }
 

--- a/editor/panes/settings.js
+++ b/editor/panes/settings.js
@@ -1,0 +1,53 @@
+import { PostFXSettings } from '../../engine/render/post/settings.js';
+
+export default class SettingsPane {
+  constructor() {
+    this.root = document.createElement('div');
+    this.root.id = 'settings-pane';
+    this.root.style.position = 'fixed';
+    this.root.style.top = '12px';
+    this.root.style.right = '12px';
+    this.root.style.background = 'rgba(20, 20, 20, 0.85)';
+    this.root.style.color = '#fff';
+    this.root.style.padding = '12px';
+    this.root.style.borderRadius = '6px';
+    this.root.style.fontFamily = 'sans-serif';
+    this.root.style.fontSize = '12px';
+    this.root.style.boxShadow = '0 2px 8px rgba(0, 0, 0, 0.3)';
+    this.root.style.minWidth = '160px';
+
+    const title = document.createElement('div');
+    title.textContent = 'Post FX';
+    title.style.fontWeight = 'bold';
+    title.style.marginBottom = '8px';
+    this.root.appendChild(title);
+
+    this.root.appendChild(this._createToggle('ACES Tonemap', 'acesTonemap'));
+    this.root.appendChild(this._createToggle('FXAA', 'fxaa'));
+
+    document.body.appendChild(this.root);
+  }
+
+  _createToggle(labelText, key) {
+    const container = document.createElement('label');
+    container.style.display = 'flex';
+    container.style.alignItems = 'center';
+    container.style.gap = '6px';
+    container.style.marginBottom = '6px';
+    container.style.cursor = 'pointer';
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = Boolean(PostFXSettings[key]);
+    checkbox.addEventListener('change', () => {
+      PostFXSettings[key] = checkbox.checked;
+    });
+
+    const label = document.createElement('span');
+    label.textContent = labelText;
+
+    container.appendChild(checkbox);
+    container.appendChild(label);
+    return container;
+  }
+}

--- a/engine/render/framegraph/index.js
+++ b/engine/render/framegraph/index.js
@@ -19,9 +19,10 @@ export default class FrameGraph {
 
   render() {
     const encoder = this.device.createCommandEncoder();
-    const view = this.context.getCurrentTexture().createView();
+    const swapChainView = this.context.getCurrentTexture().createView();
+    const context = { swapChainView };
     for (const pass of this.passes) {
-      pass.execute(encoder, view);
+      pass.execute(encoder, context);
     }
     this.device.queue.submit([encoder.finish()]);
   }

--- a/engine/render/gpu/webgpu.js
+++ b/engine/render/gpu/webgpu.js
@@ -3,6 +3,9 @@ import FrameGraph from '../framegraph/index.js';
 import ClearPass from '../passes/clearPass.js';
 import SkyPass from '../passes/skyPass.js';
 import MeshPass from '../passes/meshPass.js';
+import HDRTarget from '../post/hdr.js';
+import ACESPass from '../passes/acesPass.js';
+import FXAAPass from '../passes/fxaaPass.js';
 import Materials from '../materials/registry.js';
 
 export async function initWebGPU(canvas) {
@@ -18,10 +21,19 @@ export async function initWebGPU(canvas) {
 
   Materials.init(device);
 
+  const hdrTarget = new HDRTarget(device);
   const frameGraph = new FrameGraph(device, context);
-  frameGraph.addPass(new ClearPass(device));
-  frameGraph.addPass(new SkyPass(device, format));
-  frameGraph.addPass(new MeshPass(device, format));
+  const clearPass = new ClearPass(device, () => hdrTarget.getView());
+  const skyPass = new SkyPass(device, 'rgba16float', () => hdrTarget.getView());
+  const meshPass = new MeshPass(device, 'rgba16float', () => hdrTarget.getView());
+  const acesPass = new ACESPass(device, hdrTarget, 'rgba16float');
+  const fxaaPass = new FXAAPass(device, acesPass, format);
+
+  frameGraph.addPass(clearPass);
+  frameGraph.addPass(skyPass);
+  frameGraph.addPass(meshPass);
+  frameGraph.addPass(acesPass);
+  frameGraph.addPass(fxaaPass);
   await frameGraph.init();
 
   const runService = GetService('RunService');
@@ -41,6 +53,16 @@ export async function initWebGPU(canvas) {
       canvas.width = width;
       canvas.height = height;
       context.configure({ device, format });
+    }
+
+    const hdrChanged = hdrTarget.resize(width, height);
+    const acesChanged = acesPass.resize(width, height);
+    fxaaPass.resize(width, height);
+    if (hdrChanged) {
+      acesPass.bindGroupDirty = true;
+    }
+    if (acesChanged || hdrChanged) {
+      fxaaPass.bindGroupDirty = true;
     }
 
     frameGraph.render();

--- a/engine/render/passes/acesPass.js
+++ b/engine/render/passes/acesPass.js
@@ -1,0 +1,117 @@
+import { ACES_SHADER } from '../post/aces.js';
+import { PostFXSettings } from '../post/settings.js';
+
+export default class ACESPass {
+  constructor(device, hdrTarget, outputFormat = 'rgba16float') {
+    this.device = device;
+    this.hdrTarget = hdrTarget;
+    this.outputFormat = outputFormat;
+    this.pipeline = null;
+    this.sampler = null;
+    this.outputTexture = null;
+    this.outputView = null;
+    this.bindGroup = null;
+    this.bindGroupDirty = true;
+    this.uniformBuffer = null;
+    this.uniformArray = new Float32Array(4);
+    this.width = 0;
+    this.height = 0;
+  }
+
+  async init() {
+    const module = this.device.createShaderModule({ code: ACES_SHADER });
+    this.pipeline = this.device.createRenderPipeline({
+      layout: 'auto',
+      vertex: {
+        module,
+        entryPoint: 'vs'
+      },
+      fragment: {
+        module,
+        entryPoint: 'fs',
+        targets: [{ format: this.outputFormat }]
+      },
+      primitive: { topology: 'triangle-list' }
+    });
+
+    this.sampler = this.device.createSampler({
+      magFilter: 'linear',
+      minFilter: 'linear',
+      addressModeU: 'clamp-to-edge',
+      addressModeV: 'clamp-to-edge'
+    });
+
+    this.uniformBuffer = this.device.createBuffer({
+      size: 16,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
+    });
+  }
+
+  resize(width, height) {
+    const w = Math.max(1, Math.floor(width));
+    const h = Math.max(1, Math.floor(height));
+    if (this.outputTexture && this.width === w && this.height === h) {
+      return false;
+    }
+    if (this.outputTexture) {
+      this.outputTexture.destroy();
+    }
+    this.outputTexture = this.device.createTexture({
+      size: { width: w, height: h },
+      format: this.outputFormat,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING
+    });
+    this.width = w;
+    this.height = h;
+    this.outputView = this.outputTexture.createView();
+    this.bindGroupDirty = true;
+    return true;
+  }
+
+  getOutputView() {
+    return this.outputView;
+  }
+
+  _ensureBindGroup() {
+    if (!this.pipeline || !this.outputView || !this.hdrTarget.getView()) {
+      return;
+    }
+    if (!this.bindGroup || this.bindGroupDirty) {
+      this.bindGroup = this.device.createBindGroup({
+        layout: this.pipeline.getBindGroupLayout(0),
+        entries: [
+          { binding: 0, resource: this.hdrTarget.getView() },
+          { binding: 1, resource: this.sampler },
+          { binding: 2, resource: { buffer: this.uniformBuffer } }
+        ]
+      });
+      this.bindGroupDirty = false;
+    }
+  }
+
+  execute(encoder) {
+    if (!this.pipeline || !this.outputView) {
+      return;
+    }
+    this.uniformArray[0] = PostFXSettings.acesTonemap ? 1 : 0;
+    this.device.queue.writeBuffer(this.uniformBuffer, 0, this.uniformArray.buffer);
+    this._ensureBindGroup();
+    if (!this.bindGroup) {
+      return;
+    }
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: this.outputView,
+          clearValue: { r: 0, g: 0, b: 0, a: 1 },
+          loadOp: 'clear',
+          storeOp: 'store'
+        }
+      ]
+    });
+    pass.setPipeline(this.pipeline);
+    pass.setBindGroup(0, this.bindGroup);
+    pass.draw(3, 1, 0, 0);
+    pass.end();
+  }
+}

--- a/engine/render/passes/clearPass.js
+++ b/engine/render/passes/clearPass.js
@@ -1,10 +1,15 @@
 export default class ClearPass {
-  constructor(device, color = { r: 0.0, g: 0.0, b: 0.0, a: 1.0 }) {
+  constructor(device, getView, color = { r: 0.0, g: 0.0, b: 0.0, a: 1.0 }) {
     this.device = device;
+    this.getView = getView;
     this.color = color;
   }
 
-  execute(encoder, view) {
+  execute(encoder) {
+    const view = this.getView ? this.getView() : null;
+    if (!view) {
+      return;
+    }
     const pass = encoder.beginRenderPass({
       colorAttachments: [
         {

--- a/engine/render/passes/fxaaPass.js
+++ b/engine/render/passes/fxaaPass.js
@@ -1,0 +1,112 @@
+import { FXAA_SHADER } from '../post/fxaa.js';
+import { PostFXSettings } from '../post/settings.js';
+
+export default class FXAAPass {
+  constructor(device, acesPass, outputFormat) {
+    this.device = device;
+    this.acesPass = acesPass;
+    this.outputFormat = outputFormat;
+    this.pipeline = null;
+    this.sampler = null;
+    this.bindGroup = null;
+    this.bindGroupDirty = true;
+    this.uniformBuffer = null;
+    this.uniformArray = new Float32Array([0, 0, 1, 0]);
+    this.width = 0;
+    this.height = 0;
+  }
+
+  async init() {
+    const module = this.device.createShaderModule({ code: FXAA_SHADER });
+    this.pipeline = this.device.createRenderPipeline({
+      layout: 'auto',
+      vertex: {
+        module,
+        entryPoint: 'vs'
+      },
+      fragment: {
+        module,
+        entryPoint: 'fs',
+        targets: [{ format: this.outputFormat }]
+      },
+      primitive: { topology: 'triangle-list' }
+    });
+
+    this.sampler = this.device.createSampler({
+      magFilter: 'linear',
+      minFilter: 'linear',
+      addressModeU: 'clamp-to-edge',
+      addressModeV: 'clamp-to-edge'
+    });
+
+    this.uniformBuffer = this.device.createBuffer({
+      size: 16,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
+    });
+  }
+
+  resize(width, height) {
+    const w = Math.max(1, Math.floor(width));
+    const h = Math.max(1, Math.floor(height));
+    if (w === this.width && h === this.height) {
+      return false;
+    }
+    this.width = w;
+    this.height = h;
+    this.uniformArray[0] = 1 / w;
+    this.uniformArray[1] = 1 / h;
+    this.bindGroupDirty = true;
+    return true;
+  }
+
+  _ensureBindGroup() {
+    const inputView = this.acesPass.getOutputView();
+    if (!this.pipeline || !inputView) {
+      return;
+    }
+    if (!this.bindGroup || this.bindGroupDirty) {
+      this.bindGroup = this.device.createBindGroup({
+        layout: this.pipeline.getBindGroupLayout(0),
+        entries: [
+          { binding: 0, resource: inputView },
+          { binding: 1, resource: this.sampler },
+          { binding: 2, resource: { buffer: this.uniformBuffer } }
+        ]
+      });
+      this.bindGroupDirty = false;
+    }
+  }
+
+  execute(encoder, context) {
+    if (!this.pipeline || !context.swapChainView) {
+      return;
+    }
+
+    const inputView = this.acesPass.getOutputView();
+    if (!inputView) {
+      return;
+    }
+
+    this.uniformArray[2] = PostFXSettings.fxaa ? 1 : 0;
+    this.device.queue.writeBuffer(this.uniformBuffer, 0, this.uniformArray.buffer);
+    this._ensureBindGroup();
+    if (!this.bindGroup) {
+      return;
+    }
+
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: context.swapChainView,
+          clearValue: { r: 0, g: 0, b: 0, a: 1 },
+          loadOp: 'clear',
+          storeOp: 'store'
+        }
+      ]
+    });
+    pass.setPipeline(this.pipeline);
+    pass.setBindGroup(0, this.bindGroup);
+    pass.draw(3, 1, 0, 0);
+    pass.end();
+  }
+}

--- a/engine/render/passes/meshPass.js
+++ b/engine/render/passes/meshPass.js
@@ -1,7 +1,8 @@
 export default class MeshPass {
-  constructor(device, format) {
+  constructor(device, format, getView) {
     this.device = device;
     this.format = format;
+    this.getView = getView;
     this.pipeline = null;
     this.vertexBuffer = null;
   }
@@ -64,7 +65,11 @@ fn fs(@location(0) color : vec3f) -> @location(0) vec4f {
     this.vertexBuffer.unmap();
   }
 
-  execute(encoder, view) {
+  execute(encoder) {
+    const view = this.getView ? this.getView() : null;
+    if (!view) {
+      return;
+    }
     const pass = encoder.beginRenderPass({
       colorAttachments: [
         {

--- a/engine/render/passes/skyPass.js
+++ b/engine/render/passes/skyPass.js
@@ -1,7 +1,8 @@
 export default class SkyPass {
-  constructor(device, format) {
+  constructor(device, format, getView) {
     this.device = device;
     this.format = format;
+    this.getView = getView;
     this.pipeline = null;
   }
 
@@ -59,7 +60,11 @@ fn fs(@location(0) uv : vec2f) -> @location(0) vec4f {
     });
   }
 
-  execute(encoder, view) {
+  execute(encoder) {
+    const view = this.getView ? this.getView() : null;
+    if (!view) {
+      return;
+    }
     const pass = encoder.beginRenderPass({
       colorAttachments: [
         {

--- a/engine/render/post/aces.js
+++ b/engine/render/post/aces.js
@@ -1,0 +1,63 @@
+export const ACES_SHADER = /* wgsl */`
+struct VertexOutput {
+  @builtin(position) position : vec4f,
+  @location(0) uv : vec2f
+};
+
+@vertex
+fn vs(@builtin(vertex_index) index : u32) -> VertexOutput {
+  var positions = array<vec2f, 3>(
+    vec2f(-1.0, -3.0),
+    vec2f(-1.0,  1.0),
+    vec2f( 3.0,  1.0)
+  );
+  var uvs = array<vec2f, 3>(
+    vec2f(0.0, 2.0),
+    vec2f(0.0, 0.0),
+    vec2f(2.0, 0.0)
+  );
+  var out : VertexOutput;
+  out.position = vec4f(positions[index], 0.0, 1.0);
+  out.uv = uvs[index];
+  return out;
+}
+
+@group(0) @binding(0) var hdrTexture : texture_2d<f32>;
+@group(0) @binding(1) var hdrSampler : sampler;
+
+struct Settings {
+  data : vec4f
+};
+
+@group(0) @binding(2) var<uniform> settings : Settings;
+
+fn RRTAndODTFit(v : vec3f) -> vec3f {
+  let a = v * (v + 0.0245786) - 0.000090537;
+  let b = v * (0.983729 * v + 0.4329510) + 0.238081;
+  return clamp(a / b, vec3f(0.0), vec3f(1.0));
+}
+
+fn ACESFitted(color : vec3f) -> vec3f {
+  let acesInputMat = mat3x3f(
+    vec3f(0.59719, 0.35458, 0.04823),
+    vec3f(0.07600, 0.90834, 0.01566),
+    vec3f(0.02840, 0.13383, 0.83777)
+  );
+  let acesOutputMat = mat3x3f(
+    vec3f( 1.60475, -0.53108, -0.07367),
+    vec3f(-0.10208,  1.10813, -0.00605),
+    vec3f(-0.00327, -0.07276,  1.07602)
+  );
+  var rgb = acesInputMat * color;
+  rgb = RRTAndODTFit(rgb);
+  rgb = acesOutputMat * rgb;
+  return clamp(rgb, vec3f(0.0), vec3f(1.0));
+}
+
+@fragment
+fn fs(@location(0) uv : vec2f) -> @location(0) vec4f {
+  let hdr = textureSampleLevel(hdrTexture, hdrSampler, uv, 0.0);
+  let enabled = settings.data.x;
+  let mapped = mix(hdr.rgb, ACESFitted(hdr.rgb), vec3f(enabled));
+  return vec4f(mapped, 1.0);
+}`;

--- a/engine/render/post/fxaa.js
+++ b/engine/render/post/fxaa.js
@@ -1,0 +1,85 @@
+export const FXAA_SHADER = /* wgsl */`
+struct VertexOutput {
+  @builtin(position) position : vec4f,
+  @location(0) uv : vec2f
+};
+
+@vertex
+fn vs(@builtin(vertex_index) index : u32) -> VertexOutput {
+  var positions = array<vec2f, 3>(
+    vec2f(-1.0, -3.0),
+    vec2f(-1.0,  1.0),
+    vec2f( 3.0,  1.0)
+  );
+  var uvs = array<vec2f, 3>(
+    vec2f(0.0, 2.0),
+    vec2f(0.0, 0.0),
+    vec2f(2.0, 0.0)
+  );
+  var out : VertexOutput;
+  out.position = vec4f(positions[index], 0.0, 1.0);
+  out.uv = uvs[index];
+  return out;
+}
+
+@group(0) @binding(0) var colorTexture : texture_2d<f32>;
+@group(0) @binding(1) var colorSampler : sampler;
+
+struct Settings {
+  data : vec4f
+};
+
+@group(0) @binding(2) var<uniform> settings : Settings;
+
+fn luminance(color : vec3f) -> f32 {
+  return dot(color, vec3f(0.299, 0.587, 0.114));
+}
+
+@fragment
+fn fs(@location(0) uv : vec2f) -> @location(0) vec4f {
+  let texel = settings.data.xy;
+  let enabled = settings.data.z;
+  let center = textureSampleLevel(colorTexture, colorSampler, uv, 0.0);
+  if (enabled < 0.5) {
+    return center;
+  }
+
+  let nw = textureSampleLevel(colorTexture, colorSampler, uv + texel * vec2f(-1.0, -1.0), 0.0);
+  let ne = textureSampleLevel(colorTexture, colorSampler, uv + texel * vec2f(1.0, -1.0), 0.0);
+  let sw = textureSampleLevel(colorTexture, colorSampler, uv + texel * vec2f(-1.0, 1.0), 0.0);
+  let se = textureSampleLevel(colorTexture, colorSampler, uv + texel * vec2f(1.0, 1.0), 0.0);
+
+  let lumaNW = luminance(nw.rgb);
+  let lumaNE = luminance(ne.rgb);
+  let lumaSW = luminance(sw.rgb);
+  let lumaSE = luminance(se.rgb);
+  let lumaM = luminance(center.rgb);
+
+  let lumaMin = min(lumaM, min(min(lumaNW, lumaNE), min(lumaSW, lumaSE)));
+  let lumaMax = max(lumaM, max(max(lumaNW, lumaNE), max(lumaSW, lumaSE)));
+
+  var dir = vec2f(
+    -((lumaNW + lumaNE) - (lumaSW + lumaSE)),
+    ((lumaNW + lumaSW) - (lumaNE + lumaSE))
+  );
+
+  let dirReduce = max((lumaNW + lumaNE + lumaSW + lumaSE) * (0.25 * 0.5), 1.0 / 128.0);
+  let rcpDirMin = 1.0 / (min(abs(dir.x), abs(dir.y)) + dirReduce);
+  dir = clamp(dir * rcpDirMin * 1.5, vec2f(-8.0), vec2f(8.0));
+  dir = dir * texel;
+
+  let rgbA = 0.5 * (
+    textureSampleLevel(colorTexture, colorSampler, uv + dir * (1.0 / 3.0 - 0.5), 0.0).rgb +
+    textureSampleLevel(colorTexture, colorSampler, uv + dir * (2.0 / 3.0 - 0.5), 0.0).rgb
+  );
+  let rgbB = rgbA * 0.5 + 0.25 * (
+    textureSampleLevel(colorTexture, colorSampler, uv + dir * -0.5, 0.0).rgb +
+    textureSampleLevel(colorTexture, colorSampler, uv + dir * 0.5, 0.0).rgb
+  );
+  let lumaB = luminance(rgbB);
+  var result = rgbB;
+  if (lumaB < lumaMin || lumaB > lumaMax) {
+    result = rgbA;
+  }
+  return vec4f(result, center.a);
+}`;

--- a/engine/render/post/hdr.js
+++ b/engine/render/post/hdr.js
@@ -1,0 +1,36 @@
+export default class HDRTarget {
+  constructor(device, format = 'rgba16float') {
+    this.device = device;
+    this.format = format;
+    this.texture = null;
+    this.view = null;
+    this.width = 0;
+    this.height = 0;
+  }
+
+  resize(width, height) {
+    const nextWidth = Math.max(1, Math.floor(width));
+    const nextHeight = Math.max(1, Math.floor(height));
+    if (this.texture && this.width === nextWidth && this.height === nextHeight) {
+      return false;
+    }
+    this.width = nextWidth;
+    this.height = nextHeight;
+    if (this.texture) {
+      this.texture.destroy();
+    }
+    this.texture = this.device.createTexture({
+      size: { width: this.width, height: this.height },
+      format: this.format,
+      usage:
+        GPUTextureUsage.RENDER_ATTACHMENT |
+        GPUTextureUsage.TEXTURE_BINDING,
+    });
+    this.view = this.texture.createView();
+    return true;
+  }
+
+  getView() {
+    return this.view;
+  }
+}

--- a/engine/render/post/settings.js
+++ b/engine/render/post/settings.js
@@ -1,0 +1,4 @@
+export const PostFXSettings = {
+  acesTonemap: true,
+  fxaa: true,
+};


### PR DESCRIPTION
## Summary
- render the scene into an HDR render target and run ACES tonemapping followed by FXAA
- add dedicated passes and shaders for ACES and FXAA with resize-aware resources
- expose simple in-editor checkboxes to toggle ACES tonemapping and FXAA at runtime

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd625ed488832c9ef76190d0de8d14