### PR TITLE
Add PhysicsService collision groups with adapter scaffold

### DIFF
--- a/engine/core/index.js
+++ b/engine/core/index.js
@@ -3,6 +3,7 @@ import CollectionService from '../services/CollectionService.js';
 import TweenService from '../services/TweenService.js';
 import UserInputService from '../services/UserInputService.js';
 import RunService from '../services/RunService.js';
+import PhysicsService from '../services/PhysicsService.js';
 import { Signal } from './signal.js';
 import { isValidAttribute } from './types.js';
 
@@ -141,6 +142,10 @@ Services.set('UserInputService', userInputService);
 const runService = new Instance('RunService');
 Object.assign(runService, new RunService());
 Services.set('RunService', runService);
+
+const physicsService = new Instance('PhysicsService');
+Object.assign(physicsService, new PhysicsService());
+Services.set('PhysicsService', physicsService);
 
 function GetService(name) {
   return Services.get(name);

--- a/engine/physics/adapter.js
+++ b/engine/physics/adapter.js
@@ -1,0 +1,82 @@
+class PhysicsAdapter {
+  constructor() {
+    this._groupsByName = new Map();
+    this._groupsById = new Map();
+    this._nextGroupId = 0;
+    this._collidability = new Map(); // id -> Map<id, boolean>
+  }
+
+  _getOrCreateCollidabilityRow(groupId) {
+    if (!this._collidability.has(groupId)) {
+      this._collidability.set(groupId, new Map());
+    }
+    return this._collidability.get(groupId);
+  }
+
+  createCollisionGroup(name) {
+    if (this._groupsByName.has(name)) {
+      return this._groupsByName.get(name).id;
+    }
+
+    const id = this._nextGroupId++;
+    const group = { id, name };
+    this._groupsByName.set(name, group);
+    this._groupsById.set(id, group);
+
+    // Ensure new group collides with all existing groups by default (including itself)
+    for (const [, other] of this._groupsByName) {
+      const row = this._getOrCreateCollidabilityRow(group.id);
+      const otherRow = this._getOrCreateCollidabilityRow(other.id);
+      row.set(other.id, true);
+      otherRow.set(group.id, true);
+    }
+
+    return id;
+  }
+
+  getCollisionGroup(name) {
+    return this._groupsByName.get(name) || null;
+  }
+
+  collisionGroupsCanCollide(nameA, nameB) {
+    const groupA = this.getCollisionGroup(nameA);
+    const groupB = this.getCollisionGroup(nameB);
+    if (!groupA || !groupB) {
+      return true;
+    }
+    const row = this._collidability.get(groupA.id);
+    if (!row) {
+      return true;
+    }
+    const value = row.get(groupB.id);
+    return value !== undefined ? value : true;
+  }
+
+  setCollisionGroupsCollidable(nameA, nameB, canCollide) {
+    const groupA = this.getCollisionGroup(nameA);
+    const groupB = this.getCollisionGroup(nameB);
+    if (!groupA || !groupB) {
+      return;
+    }
+    const rowA = this._getOrCreateCollidabilityRow(groupA.id);
+    const rowB = this._getOrCreateCollidabilityRow(groupB.id);
+    rowA.set(groupB.id, !!canCollide);
+    rowB.set(groupA.id, !!canCollide);
+  }
+
+  collisionGroupContainsInstance(groupName, instance) {
+    if (!instance) return false;
+    if (typeof instance.GetAttribute === 'function') {
+      const attr = instance.GetAttribute('CollisionGroup');
+      if (attr === groupName) {
+        return true;
+      }
+    }
+    if (instance.CollisionGroup === groupName) {
+      return true;
+    }
+    return false;
+  }
+}
+
+export default PhysicsAdapter;

--- a/engine/services/PhysicsService.js
+++ b/engine/services/PhysicsService.js
@@ -1,0 +1,22 @@
+import PhysicsAdapter from '../physics/adapter.js';
+
+export default class PhysicsService {
+  constructor(adapter = new PhysicsAdapter()) {
+    this._adapter = adapter;
+    this.CreateCollisionGroup = name => {
+      return this._adapter.createCollisionGroup(name);
+    };
+
+    this.CollisionGroupsAreCollidable = (groupA, groupB) => {
+      return this._adapter.collisionGroupsCanCollide(groupA, groupB);
+    };
+
+    this.CollisionGroupSetCollidable = (groupA, groupB, canCollide) => {
+      this._adapter.setCollisionGroupsCollidable(groupA, groupB, canCollide);
+    };
+
+    this.CollisionGroupContainsPart = (group, instance) => {
+      return this._adapter.collisionGroupContainsInstance(group, instance);
+    };
+  }
+}

--- a/tests/ava/physics-collisions.test.js
+++ b/tests/ava/physics-collisions.test.js
@@ -1,0 +1,55 @@
+import test from 'ava';
+import { Instance, GetService } from '../../engine/core/index.js';
+
+const PS = () => GetService('PhysicsService');
+
+// Create collision groups and verify ids/collidability defaults
+
+test('create collision groups maintain ids and defaults', t => {
+  const physics = PS();
+  const groupAId = physics.CreateCollisionGroup('TestGroupA');
+  const groupBId = physics.CreateCollisionGroup('TestGroupB');
+
+  t.true(Number.isInteger(groupAId));
+  t.true(Number.isInteger(groupBId));
+  t.not(groupAId, groupBId);
+  t.is(physics.CreateCollisionGroup('TestGroupA'), groupAId);
+
+  t.true(physics.CollisionGroupsAreCollidable('TestGroupA', 'TestGroupB'));
+  t.true(physics.CollisionGroupsAreCollidable('TestGroupA', 'TestGroupA'));
+  t.true(physics.CollisionGroupsAreCollidable('TestGroupB', 'TestGroupB'));
+});
+
+// Toggle collidability and ensure symmetry
+
+test('collision group collidability toggle', t => {
+  const physics = PS();
+  physics.CreateCollisionGroup('ToggleGroupA');
+  physics.CreateCollisionGroup('ToggleGroupB');
+
+  physics.CollisionGroupSetCollidable('ToggleGroupA', 'ToggleGroupB', false);
+  t.false(physics.CollisionGroupsAreCollidable('ToggleGroupA', 'ToggleGroupB'));
+  t.false(physics.CollisionGroupsAreCollidable('ToggleGroupB', 'ToggleGroupA'));
+
+  physics.CollisionGroupSetCollidable('ToggleGroupA', 'ToggleGroupB', true);
+  t.true(physics.CollisionGroupsAreCollidable('ToggleGroupA', 'ToggleGroupB'));
+});
+
+// CollisionGroupContainsPart uses attribute or property as placeholder membership
+
+test('collision group contains part via attribute or property', t => {
+  const physics = PS();
+  physics.CreateCollisionGroup('PartsGroup');
+
+  const part = new Instance('Part');
+  t.false(physics.CollisionGroupContainsPart('PartsGroup', part));
+
+  part.SetAttribute('CollisionGroup', 'PartsGroup');
+  t.true(physics.CollisionGroupContainsPart('PartsGroup', part));
+
+  part.SetAttribute('CollisionGroup', 'OtherGroup');
+  t.false(physics.CollisionGroupContainsPart('PartsGroup', part));
+
+  part.CollisionGroup = 'PartsGroup';
+  t.true(physics.CollisionGroupContainsPart('PartsGroup', part));
+});


### PR DESCRIPTION
## Summary
- add a physics adapter scaffold that tracks collision groups and their collidability matrix
- expose collision group APIs through PhysicsService and register it with the engine services
- cover collision group behavior with new AVA tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd6745267c832ca1fa980a7d48c1d7