### PR TITLE
Implement editor selection flow with gizmo binding

### DIFF
--- a/editor/app/main.js
+++ b/editor/app/main.js
@@ -5,10 +5,17 @@ import GitPane from '../panes/git.js';
 import { initViewport } from '../services/viewport.js';
 import { checkForUpdates } from '../services/update-checker.js';
 import SettingsPane from '../panes/settings.js';
+import UndoService from '../services/undo.js';
+import { Selection } from '../services/selection.js';
+import TranslationGizmo from '../components/gizmos.js';
 
 export function bootstrap() {
-  new Explorer();
-  new Properties();
+  const undo = new UndoService();
+  const selection = new Selection();
+
+  new Explorer(undo, selection);
+  new Properties(undo, selection);
+  new TranslationGizmo(selection, undo);
   initViewport();
   new ConsolePane();
   new GitPane();

--- a/editor/components/gizmos.js
+++ b/editor/components/gizmos.js
@@ -1,0 +1,92 @@
+import UndoService from '../services/undo.js';
+import { Selection } from '../services/selection.js';
+
+function cloneVector(value = {}) {
+  return {
+    x: typeof value.x === 'number' ? value.x : 0,
+    y: typeof value.y === 'number' ? value.y : 0,
+    z: typeof value.z === 'number' ? value.z : 0,
+  };
+}
+
+function vectorsEqual(a, b) {
+  return a.x === b.x && a.y === b.y && a.z === b.z;
+}
+
+function createCommand(inst, before, after) {
+  const prev = { ...before };
+  const next = { ...after };
+  return {
+    undo: () => inst.setProperty('Position', { ...prev }),
+    redo: () => inst.setProperty('Position', { ...next }),
+  };
+}
+
+export default class TranslationGizmo {
+  constructor(selection = new Selection(), undo = new UndoService()) {
+    this.selection = selection;
+    this.undo = undo;
+    this.axis = null;
+    this.original = new Map();
+    this.targets = [];
+
+    this.selectionConn = this.selection.Changed.Connect(sel => {
+      this.targets = [...sel];
+      this.original.clear();
+      this.axis = null;
+    });
+
+    this.targets = this.selection.get();
+  }
+
+  dispose() {
+    if (this.selectionConn) this.selectionConn.Disconnect();
+    this.original.clear();
+  }
+
+  beginDrag(axis) {
+    if (!axis) return;
+    this.axis = axis;
+    this.original.clear();
+    for (const inst of this.targets) {
+      this.original.set(inst, cloneVector(inst.Position));
+    }
+  }
+
+  drag(offset) {
+    if (!this.axis) return;
+    for (const inst of this.targets) {
+      const start = this.original.get(inst) || cloneVector(inst.Position);
+      const updated = { ...start, [this.axis]: start[this.axis] + offset };
+      inst.setProperty('Position', updated);
+    }
+  }
+
+  endDrag() {
+    if (!this.axis) return;
+    const commands = [];
+    for (const inst of this.targets) {
+      const before = this.original.get(inst) || cloneVector(inst.Position);
+      const after = cloneVector(inst.Position);
+      if (!vectorsEqual(before, after)) {
+        commands.push(createCommand(inst, before, after));
+      }
+    }
+
+    if (commands.length === 1) {
+      this.undo.execute(commands[0]);
+    } else if (commands.length > 1) {
+      this.undo.execute({
+        undo: () => {
+          for (const cmd of [...commands].reverse()) cmd.undo();
+        },
+        redo: () => {
+          for (const cmd of commands) cmd.redo();
+        },
+      });
+    }
+
+    this.axis = null;
+    this.original.clear();
+  }
+}

--- a/editor/panes/explorer.js
+++ b/editor/panes/explorer.js
@@ -1,13 +1,52 @@
 import { Instance } from '../../engine/core/index.js';
 import UndoService from '../services/undo.js';
-import SelectionService from '../services/selection.js';
+import { Selection } from '../services/selection.js';
 
 // Minimal Explorer pane logic providing creation and deletion actions
 // hooked into the undo service.
 export default class Explorer {
-  constructor(undo = new UndoService(), selection = new SelectionService()) {
+  constructor(undo = new UndoService(), selection = new Selection()) {
     this.undo = undo;
     this.selection = selection;
+    this.nodes = new Set();
+  }
+
+  register(inst) {
+    if (inst) this.nodes.add(inst);
+  }
+
+  unregister(inst) {
+    if (!inst) return;
+    this.nodes.delete(inst);
+    if (this.selection.isSelected(inst)) {
+      this.selection.remove(inst);
+    }
+  }
+
+  click(inst, { additive = false, toggle = false } = {}) {
+    if (!inst) {
+      this.selection.clear();
+      return this.selection.get();
+    }
+
+    this.register(inst);
+
+    if (toggle && this.selection.isSelected(inst)) {
+      this.selection.remove(inst);
+      return this.selection.get();
+    }
+
+    if (additive) {
+      this.selection.add(inst);
+    } else {
+      this.selection.set([inst]);
+    }
+
+    return this.selection.get();
+  }
+
+  isSelected(inst) {
+    return this.selection.isSelected(inst);
   }
 
   addModel() {

--- a/editor/panes/properties.js
+++ b/editor/panes/properties.js
@@ -1,14 +1,149 @@
 import UndoService from '../services/undo.js';
+import { Selection } from '../services/selection.js';
+
+const VECTOR_PROPS = ['Position', 'Rotation', 'Scale'];
+
+function cloneVector(value = {}) {
+  return {
+    x: typeof value.x === 'number' ? value.x : 0,
+    y: typeof value.y === 'number' ? value.y : 0,
+    z: typeof value.z === 'number' ? value.z : 0,
+  };
+}
+
+function buildVectorField(instances, prop) {
+  const vectors = instances.map(inst => cloneVector(inst[prop]));
+  if (!vectors.length) {
+    return { value: cloneVector(), mixed: { x: false, y: false, z: false } };
+  }
+
+  const base = vectors[0];
+  const mixed = { x: false, y: false, z: false };
+  for (const vec of vectors.slice(1)) {
+    for (const axis of ['x', 'y', 'z']) {
+      if (base[axis] !== vec[axis]) {
+        mixed[axis] = true;
+      }
+    }
+  }
+
+  return { value: { ...base }, mixed };
+}
+
+function buildNameField(instances) {
+  if (!instances.length) return { value: '', mixed: false };
+  const name = instances[0].Name ?? '';
+  const mixed = instances.some(inst => (inst.Name ?? '') !== name);
+  return { value: mixed ? '' : name, mixed };
+}
+
+function combineCommands(undo, commands) {
+  if (!commands.length) return;
+  if (commands.length === 1) {
+    undo.execute(commands[0]);
+    return;
+  }
+
+  undo.execute({
+    undo: () => {
+      for (const cmd of [...commands].reverse()) {
+        cmd.undo();
+      }
+    },
+    redo: () => {
+      for (const cmd of commands) {
+        cmd.redo();
+      }
+    },
+  });
+}
 
 // Minimal properties pane. Editing a numeric property pushes an undo entry.
 export default class Properties {
-  constructor(undo = new UndoService()) {
+  constructor(undo = new UndoService(), selection = new Selection()) {
     this.undo = undo;
+    this.selection = selection;
+    this.boundInstances = [];
+    this.boundConnections = [];
+    this.current = null;
+
+    this.selectionConnection = this.selection.Changed.Connect(sel => {
+      this._bindInstances(sel);
+    });
+
+    this._bindInstances(this.selection.get());
+  }
+
+  dispose() {
+    if (this.selectionConnection) this.selectionConnection.Disconnect();
+    this._disconnectBound();
+  }
+
+  getCurrent() {
+    return this.current;
   }
 
   editNumber(inst, prop, value) {
     const num = Number(value);
     if (Number.isNaN(num)) return;
     this.undo.execute(this.undo.setProperty(inst, prop, num));
+  }
+
+  editName(value) {
+    const text = String(value ?? '');
+    const commands = this.boundInstances.map(inst => this.undo.setProperty(inst, 'Name', text));
+    combineCommands(this.undo, commands);
+  }
+
+  editVectorComponent(prop, axis, value) {
+    if (!VECTOR_PROPS.includes(prop)) return;
+    const num = Number(value);
+    if (Number.isNaN(num)) return;
+
+    const commands = [];
+    for (const inst of this.boundInstances) {
+      const current = cloneVector(inst[prop]);
+      if (current[axis] === num) continue;
+      const next = { ...current, [axis]: num };
+      commands.push({
+        undo: () => inst.setProperty(prop, { ...current }),
+        redo: () => inst.setProperty(prop, { ...next }),
+      });
+    }
+
+    combineCommands(this.undo, commands);
+  }
+
+  _bindInstances(instances) {
+    this._disconnectBound();
+    this.boundInstances = [...instances];
+    this.current = this._buildState();
+
+    for (const inst of this.boundInstances) {
+      this.boundConnections.push(
+        inst.Changed.Connect(prop => {
+          if (prop === 'Name' || VECTOR_PROPS.includes(prop)) {
+            this.current = this._buildState();
+          }
+        }),
+      );
+    }
+  }
+
+  _disconnectBound() {
+    for (const conn of this.boundConnections) {
+      conn.Disconnect();
+    }
+    this.boundConnections = [];
+  }
+
+  _buildState() {
+    const instances = this.boundInstances;
+    return {
+      Name: buildNameField(instances),
+      Position: buildVectorField(instances, 'Position'),
+      Rotation: buildVectorField(instances, 'Rotation'),
+      Scale: buildVectorField(instances, 'Scale'),
+    };
   }
 }

--- a/editor/services/selection.js
+++ b/editor/services/selection.js
@@ -1,38 +1,80 @@
 import { Signal } from '../../engine/core/signal.js';
 
-// Basic selection service used by the editor. Keeps a list of selected
-// Instances and emits a signal when the selection changes.
-export default class SelectionService {
+// Selection service shared by the editor. Tracks the current selection and
+// notifies listeners through the Changed signal whenever the selection
+// contents are updated.
+class Selection {
   constructor() {
-    this.selection = [];
-    this.SelectionChanged = new Signal();
+    this._selection = [];
+    this._primary = null;
+    this.Changed = new Signal();
   }
 
+  /**
+   * Retrieve a shallow copy of the selected instances.
+   */
+  get() {
+    return [...this._selection];
+  }
+
+  // Backwards compatible alias with earlier prompt tasks.
   getSelection() {
-    return [...this.selection];
+    return this.get();
   }
 
+  getPrimary() {
+    return this._primary;
+  }
+
+  set(items) {
+    const newList = [];
+    const seen = new Set();
+    for (const item of items) {
+      if (!item || seen.has(item)) continue;
+      seen.add(item);
+      newList.push(item);
+    }
+
+    if (this._isSame(newList)) return;
+
+    this._selection = newList;
+    this._primary = newList.length ? newList[0] : null;
+    this.Changed.Fire(this.get());
+  }
+
+  // Backwards compatible alias with earlier prompt tasks.
   setSelection(items) {
-    this.selection = [...items];
-    this.SelectionChanged.Fire(this.getSelection());
+    this.set(items);
   }
 
   clear() {
-    this.setSelection([]);
+    this.set([]);
   }
 
   add(item) {
-    if (!this.selection.includes(item)) {
-      this.selection.push(item);
-      this.SelectionChanged.Fire(this.getSelection());
-    }
+    if (!item) return;
+    if (this._selection.includes(item)) return;
+    this.set([...this._selection, item]);
   }
 
   remove(item) {
-    const idx = this.selection.indexOf(item);
-    if (idx !== -1) {
-      this.selection.splice(idx, 1);
-      this.SelectionChanged.Fire(this.getSelection());
+    if (!item) return;
+    if (!this._selection.includes(item)) return;
+    this.set(this._selection.filter(i => i !== item));
+  }
+
+  isSelected(item) {
+    return this._selection.includes(item);
+  }
+
+  _isSame(other) {
+    if (other.length !== this._selection.length) return false;
+    for (let i = 0; i < other.length; i += 1) {
+      if (other[i] !== this._selection[i]) return false;
     }
+    return true;
   }
 }
+
+export { Selection };
+export default Selection;

--- a/tests/ava/editor-selection.test.js
+++ b/tests/ava/editor-selection.test.js
@@ -1,0 +1,70 @@
+import test from 'ava';
+import { Instance } from '../../engine/core/index.js';
+import UndoService from '../../editor/services/undo.js';
+import { Selection } from '../../editor/services/selection.js';
+import Explorer from '../../editor/panes/explorer.js';
+import Properties from '../../editor/panes/properties.js';
+import TranslationGizmo from '../../editor/components/gizmos.js';
+
+function createMeshInstance(name = 'Mesh') {
+  const inst = new Instance('MeshPart');
+  inst.setProperty('Name', name);
+  inst.setProperty('Position', { x: 0, y: 0, z: 0 });
+  inst.setProperty('Rotation', { x: 0, y: 0, z: 0 });
+  inst.setProperty('Scale', { x: 1, y: 1, z: 1 });
+  return inst;
+}
+
+test('selecting a node populates properties', t => {
+  const undo = new UndoService();
+  const selection = new Selection();
+  const explorer = new Explorer(undo, selection);
+  const properties = new Properties(undo, selection);
+
+  const mesh = createMeshInstance('Crate');
+  explorer.register(mesh);
+  explorer.click(mesh);
+
+  t.true(explorer.isSelected(mesh));
+
+  const current = properties.getCurrent();
+  t.is(current.Name.value, 'Crate');
+  t.deepEqual(current.Position.value, { x: 0, y: 0, z: 0 });
+
+  properties.editVectorComponent('Position', 'x', 5);
+  t.is(mesh.Position.x, 5);
+  t.is(properties.getCurrent().Position.value.x, 5);
+});
+
+test('gizmo drag updates position and pushes undo', t => {
+  const undo = new UndoService();
+  const selection = new Selection();
+  const explorer = new Explorer(undo, selection);
+  const properties = new Properties(undo, selection);
+  const gizmo = new TranslationGizmo(selection, undo);
+
+  const mesh = createMeshInstance();
+  explorer.register(mesh);
+  explorer.click(mesh);
+
+  let changedCount = 0;
+  mesh.Changed.Connect(prop => {
+    if (prop === 'Position') changedCount += 1;
+  });
+
+  gizmo.beginDrag('x');
+  gizmo.drag(3);
+  gizmo.endDrag();
+
+  t.is(mesh.Position.x, 3);
+  t.true(changedCount > 0);
+  t.is(properties.getCurrent().Position.value.x, 3);
+
+  undo.undo();
+  t.is(mesh.Position.x, 0);
+
+  undo.redo();
+  t.is(mesh.Position.x, 3);
+
+  gizmo.dispose();
+});


### PR DESCRIPTION
## Summary
- introduce a shared selection service with a Changed signal and expose helper APIs
- wire explorer, properties and new translation gizmo to react to selection updates and push undo commands
- keep properties pane in sync with transforms and verify behaviour via new editor selection AVA tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd6a1328b8832ca0f378af5c07a450