### PR TITLE
Add in-editor profiler overlay with frame statistics

### DIFF
--- a/editor/app/main.js
+++ b/editor/app/main.js
@@ -5,6 +5,7 @@ import GitPane from '../panes/git.js';
 import { initViewport } from '../services/viewport.js';
 import { checkForUpdates } from '../services/update-checker.js';
 import SettingsPane from '../panes/settings.js';
+import ProfilerPane from '../panes/profiler.js';
 import UndoService from '../services/undo.js';
 import { Selection } from '../services/selection.js';
 import TranslationGizmo from '../components/gizmos.js';
@@ -19,7 +20,8 @@ export function bootstrap() {
   initViewport();
   new ConsolePane();
   new GitPane();
-  new SettingsPane();
+  const profiler = new ProfilerPane();
+  new SettingsPane({ profiler });
   checkForUpdates();
 }
 

--- a/editor/panes/profiler.js
+++ b/editor/panes/profiler.js
@@ -1,0 +1,148 @@
+import { getFrameStats } from '../../engine/render/framegraph/stats.js';
+
+function createStatRow(label) {
+  const row = document.createElement('div');
+  row.style.display = 'flex';
+  row.style.justifyContent = 'space-between';
+  row.style.alignItems = 'center';
+  row.style.gap = '12px';
+
+  const labelEl = document.createElement('span');
+  labelEl.textContent = label;
+  labelEl.style.opacity = '0.75';
+
+  const valueEl = document.createElement('span');
+  valueEl.style.fontVariantNumeric = 'tabular-nums';
+
+  row.appendChild(labelEl);
+  row.appendChild(valueEl);
+
+  return { row, valueEl };
+}
+
+export default class ProfilerPane {
+  constructor() {
+    this.enabled = true;
+    this.latestStats = null;
+    this.passRows = new Map();
+
+    this.root = document.createElement('div');
+    this.root.id = 'profiler-pane';
+    this.root.style.position = 'fixed';
+    this.root.style.bottom = '12px';
+    this.root.style.left = '12px';
+    this.root.style.background = 'rgba(20, 20, 20, 0.85)';
+    this.root.style.color = '#fff';
+    this.root.style.padding = '12px';
+    this.root.style.borderRadius = '6px';
+    this.root.style.fontFamily = 'monospace';
+    this.root.style.fontSize = '12px';
+    this.root.style.boxShadow = '0 2px 8px rgba(0, 0, 0, 0.3)';
+    this.root.style.minWidth = '180px';
+    this.root.style.pointerEvents = 'none';
+    this.root.style.userSelect = 'none';
+    this.root.style.lineHeight = '1.4';
+
+    const title = document.createElement('div');
+    title.textContent = 'Profiler';
+    title.style.fontWeight = 'bold';
+    title.style.marginBottom = '8px';
+    this.root.appendChild(title);
+
+    const fpsRow = createStatRow('FPS');
+    this.fpsValue = fpsRow.valueEl;
+    this.root.appendChild(fpsRow.row);
+
+    const frameTimeRow = createStatRow('CPU Frame (ms)');
+    this.frameTimeValue = frameTimeRow.valueEl;
+    this.root.appendChild(frameTimeRow.row);
+
+    const gpuRow = createStatRow('GPU');
+    this.gpuValue = gpuRow.valueEl;
+    this.root.appendChild(gpuRow.row);
+
+    const totalDrawRow = createStatRow('Draw Calls');
+    this.totalDrawValue = totalDrawRow.valueEl;
+    this.root.appendChild(totalDrawRow.row);
+
+    const divider = document.createElement('div');
+    divider.style.height = '1px';
+    divider.style.background = 'rgba(255, 255, 255, 0.1)';
+    divider.style.margin = '8px 0';
+    this.root.appendChild(divider);
+
+    const passTitle = document.createElement('div');
+    passTitle.textContent = 'Passes';
+    passTitle.style.opacity = '0.75';
+    passTitle.style.marginBottom = '4px';
+    this.root.appendChild(passTitle);
+
+    this.drawCallsContainer = document.createElement('div');
+    this.drawCallsContainer.style.display = 'flex';
+    this.drawCallsContainer.style.flexDirection = 'column';
+    this.drawCallsContainer.style.gap = '2px';
+    this.root.appendChild(this.drawCallsContainer);
+
+    document.body.appendChild(this.root);
+
+    this._update = this._update.bind(this);
+    requestAnimationFrame(this._update);
+  }
+
+  isVisible() {
+    return this.enabled;
+  }
+
+  setVisible(visible) {
+    this.enabled = Boolean(visible);
+    this.root.style.display = this.enabled ? 'block' : 'none';
+    if (this.enabled && this.latestStats) {
+      this._render(this.latestStats);
+    }
+  }
+
+  _update() {
+    this.latestStats = getFrameStats();
+    if (this.enabled) {
+      this._render(this.latestStats);
+    }
+    requestAnimationFrame(this._update);
+  }
+
+  _render(stats) {
+    const fps = Number.isFinite(stats.fps) ? stats.fps : 0;
+    const frameTime = Number.isFinite(stats.cpuFrameTime) ? stats.cpuFrameTime : 0;
+    const totalDrawCalls = typeof stats.totalDrawCalls === 'number' ? stats.totalDrawCalls : 0;
+
+    this.fpsValue.textContent = fps.toFixed(1);
+    this.frameTimeValue.textContent = frameTime.toFixed(2);
+    this.gpuValue.textContent = stats.gpuAdapterName || 'Detecting…';
+    this.totalDrawValue.textContent = totalDrawCalls.toString();
+
+    this._syncPassRows(stats.passes || {});
+  }
+
+  _syncPassRows(passes) {
+    const seen = new Set();
+    for (const name of Object.keys(passes)) {
+      seen.add(name);
+      let entry = this.passRows.get(name);
+      if (!entry) {
+        const { row, valueEl } = createStatRow(name);
+        row.style.paddingLeft = '4px';
+        valueEl.style.fontVariantNumeric = 'tabular-nums';
+        entry = { row, valueEl };
+        this.passRows.set(name, entry);
+        this.drawCallsContainer.appendChild(row);
+      }
+      entry.valueEl.textContent = passes[name].drawCalls.toString();
+    }
+
+    for (const [name, entry] of this.passRows.entries()) {
+      if (!seen.has(name)) {
+        entry.row.remove();
+        this.passRows.delete(name);
+      }
+    }
+  }
+}

--- a/editor/panes/settings.js
+++ b/editor/panes/settings.js
@@ -1,7 +1,7 @@
 import { PostFXSettings } from '../../engine/render/post/settings.js';
 
 export default class SettingsPane {
-  constructor() {
+  constructor({ profiler } = {}) {
     this.root = document.createElement('div');
     this.root.id = 'settings-pane';
     this.root.style.position = 'fixed';
@@ -16,19 +16,43 @@ export default class SettingsPane {
     this.root.style.boxShadow = '0 2px 8px rgba(0, 0, 0, 0.3)';
     this.root.style.minWidth = '160px';
 
-    const title = document.createElement('div');
-    title.textContent = 'Post FX';
-    title.style.fontWeight = 'bold';
-    title.style.marginBottom = '8px';
-    this.root.appendChild(title);
+    this.root.appendChild(this._createSectionTitle('Post FX'));
+    this.root.appendChild(this._createToggle('ACES Tonemap', {
+      initial: Boolean(PostFXSettings.acesTonemap),
+      onChange: value => {
+        PostFXSettings.acesTonemap = value;
+      },
+    }));
+    this.root.appendChild(this._createToggle('FXAA', {
+      initial: Boolean(PostFXSettings.fxaa),
+      onChange: value => {
+        PostFXSettings.fxaa = value;
+      },
+    }));
 
-    this.root.appendChild(this._createToggle('ACES Tonemap', 'acesTonemap'));
-    this.root.appendChild(this._createToggle('FXAA', 'fxaa'));
+    if (profiler) {
+      this.root.appendChild(this._createSectionTitle('Diagnostics'));
+      this.root.appendChild(this._createToggle('Show Profiler', {
+        initial: profiler.isVisible(),
+        onChange: value => profiler.setVisible(value),
+      }));
+    }
 
     document.body.appendChild(this.root);
   }
 
-  _createToggle(labelText, key) {
+  _createSectionTitle(text) {
+    const title = document.createElement('div');
+    title.textContent = text;
+    title.style.fontWeight = 'bold';
+    title.style.marginBottom = '8px';
+    if (this.root.children.length > 0) {
+      title.style.marginTop = '12px';
+    }
+    return title;
+  }
+
+  _createToggle(labelText, { initial = false, onChange } = {}) {
     const container = document.createElement('label');
     container.style.display = 'flex';
     container.style.alignItems = 'center';
@@ -38,10 +62,12 @@ export default class SettingsPane {
 
     const checkbox = document.createElement('input');
     checkbox.type = 'checkbox';
-    checkbox.checked = Boolean(PostFXSettings[key]);
-    checkbox.addEventListener('change', () => {
-      PostFXSettings[key] = checkbox.checked;
-    });
+    checkbox.checked = Boolean(initial);
+    if (typeof onChange === 'function') {
+      checkbox.addEventListener('change', () => {
+        onChange(checkbox.checked);
+      });
+    }
 
     const label = document.createElement('span');
     label.textContent = labelText;

--- a/engine/render/framegraph/index.js
+++ b/engine/render/framegraph/index.js
@@ -1,3 +1,5 @@
+import { beginFrame, endFrame, markPass } from './stats.js';
+
 export default class FrameGraph {
   constructor(device, context) {
     this.device = device;
@@ -18,13 +20,19 @@ export default class FrameGraph {
   }
 
   render() {
+    beginFrame();
     const encoder = this.device.createCommandEncoder();
     const swapChainView = this.context.getCurrentTexture().createView();
     const context = { swapChainView };
     for (const pass of this.passes) {
+      const passName = typeof pass.getName === 'function'
+        ? pass.getName()
+        : (pass.name || (pass.constructor && pass.constructor.name) || 'Pass');
+      markPass(passName);
       pass.execute(encoder, context);
     }
     this.device.queue.submit([encoder.finish()]);
+    endFrame();
   }
 }
 

--- a/engine/render/framegraph/stats.js
+++ b/engine/render/framegraph/stats.js
@@ -1,0 +1,67 @@
+const now = () => {
+  if (typeof performance !== 'undefined' && performance.now) {
+    return performance.now();
+  }
+  return Date.now();
+};
+
+const frameStats = {
+  fps: 0,
+  cpuFrameTime: 0,
+  gpuAdapterName: '',
+  totalDrawCalls: 0,
+  passes: {},
+  renderCpuTime: 0,
+};
+
+let frameStartTime = 0;
+
+export function beginFrame() {
+  frameStartTime = now();
+  frameStats.totalDrawCalls = 0;
+  frameStats.passes = {};
+}
+
+export function endFrame() {
+  frameStats.renderCpuTime = now() - frameStartTime;
+}
+
+export function markPass(name) {
+  const passName = name || 'Pass';
+  if (!frameStats.passes[passName]) {
+    frameStats.passes[passName] = { drawCalls: 0 };
+  }
+}
+
+export function recordDrawCall(name, count = 1) {
+  const passName = name || 'Pass';
+  markPass(passName);
+  frameStats.passes[passName].drawCalls += count;
+  frameStats.totalDrawCalls += count;
+}
+
+export function updateFrameMetrics(deltaSeconds) {
+  if (!Number.isFinite(deltaSeconds) || deltaSeconds <= 0) {
+    return;
+  }
+
+  const fps = 1 / deltaSeconds;
+  const frameTimeMs = deltaSeconds * 1000;
+
+  if (frameStats.fps === 0) {
+    frameStats.fps = fps;
+    frameStats.cpuFrameTime = frameTimeMs;
+  } else {
+    const smoothing = 0.9;
+    frameStats.fps = frameStats.fps * smoothing + fps * (1 - smoothing);
+    frameStats.cpuFrameTime = frameStats.cpuFrameTime * smoothing + frameTimeMs * (1 - smoothing);
+  }
+}
+
+export function setGPUAdapterName(name) {
+  frameStats.gpuAdapterName = name || '';
+}
+
+export function getFrameStats() {
+  return frameStats;
+}

--- a/engine/render/gpu/webgpu.js
+++ b/engine/render/gpu/webgpu.js
@@ -7,6 +7,7 @@ import HDRTarget from '../post/hdr.js';
 import ACESPass from '../passes/acesPass.js';
 import FXAAPass from '../passes/fxaaPass.js';
 import Materials from '../materials/registry.js';
+import { setGPUAdapterName, updateFrameMetrics } from '../framegraph/stats.js';
 
 export async function initWebGPU(canvas) {
   if (!navigator.gpu) {
@@ -14,6 +15,11 @@ export async function initWebGPU(canvas) {
     return;
   }
   const adapter = await navigator.gpu.requestAdapter();
+  if (!adapter) {
+    console.warn('Failed to acquire GPU adapter');
+    return;
+  }
+  setGPUAdapterName(adapter.name || 'Unknown GPU');
   const device = await adapter.requestDevice();
   const context = canvas.getContext('webgpu');
   const format = navigator.gpu.getPreferredCanvasFormat();
@@ -44,6 +50,8 @@ export async function initWebGPU(canvas) {
     const now = ts / 1000;
     const dt = now - last;
     last = now;
+
+    updateFrameMetrics(dt);
 
     runService._step(dt);
 

--- a/engine/render/passes/acesPass.js
+++ b/engine/render/passes/acesPass.js
@@ -1,5 +1,6 @@
 import { ACES_SHADER } from '../post/aces.js';
 import { PostFXSettings } from '../post/settings.js';
+import { recordDrawCall } from '../framegraph/stats.js';
 
 export default class ACESPass {
   constructor(device, hdrTarget, outputFormat = 'rgba16float') {
@@ -112,6 +113,7 @@ export default class ACESPass {
     pass.setPipeline(this.pipeline);
     pass.setBindGroup(0, this.bindGroup);
     pass.draw(3, 1, 0, 0);
+    recordDrawCall(this.constructor.name);
     pass.end();
   }
 }

--- a/engine/render/passes/fxaaPass.js
+++ b/engine/render/passes/fxaaPass.js
@@ -1,5 +1,6 @@
 import { FXAA_SHADER } from '../post/fxaa.js';
 import { PostFXSettings } from '../post/settings.js';
+import { recordDrawCall } from '../framegraph/stats.js';
 
 export default class FXAAPass {
   constructor(device, acesPass, outputFormat) {
@@ -107,6 +108,7 @@ export default class FXAAPass {
     pass.setPipeline(this.pipeline);
     pass.setBindGroup(0, this.bindGroup);
     pass.draw(3, 1, 0, 0);
+    recordDrawCall(this.constructor.name);
     pass.end();
   }
 }

--- a/engine/render/passes/meshPass.js
+++ b/engine/render/passes/meshPass.js
@@ -1,3 +1,5 @@
+import { recordDrawCall } from '../framegraph/stats.js';
+
 export default class MeshPass {
   constructor(device, format, getView) {
     this.device = device;
@@ -82,6 +84,7 @@ fn fs(@location(0) color : vec3f) -> @location(0) vec4f {
     pass.setPipeline(this.pipeline);
     pass.setVertexBuffer(0, this.vertexBuffer);
     pass.draw(3, 1, 0, 0);
+    recordDrawCall(this.constructor.name);
     pass.end();
   }
 }

--- a/engine/render/passes/skyPass.js
+++ b/engine/render/passes/skyPass.js
@@ -1,3 +1,5 @@
+import { recordDrawCall } from '../framegraph/stats.js';
+
 export default class SkyPass {
   constructor(device, format, getView) {
     this.device = device;
@@ -76,6 +78,7 @@ fn fs(@location(0) uv : vec2f) -> @location(0) vec4f {
     });
     pass.setPipeline(this.pipeline);
     pass.draw(6, 1, 0, 0);
+    recordDrawCall(this.constructor.name);
     pass.end();
   }
 }


### PR DESCRIPTION
## Summary
- add a framegraph stats tracker for FPS, CPU frame time, draw calls, and adapter name
- surface stats in a new in-editor profiler overlay with a Settings toggle
- instrument render passes and WebGPU initialization to feed profiler metrics

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd74901644832ca2e00e92439d87e1