### PR TITLE
Fix module asset serving paths

### DIFF
--- a/editor/app/dev-server.js
+++ b/editor/app/dev-server.js
@@ -2,16 +2,71 @@ import http from 'http';
 import { promises as fs } from 'fs';
 import path from 'path';
 
-const base = path.resolve('public');
-const server = http.createServer(async (req, res) => {
-  const filePath = path.join(base, req.url === '/' ? '/index.html' : req.url);
+const repoRoot = path.resolve('.');
+const publicDir = path.resolve('public');
+const indexPath = path.join(publicDir, 'index.html');
+
+const mimeTypes = {
+  '.css': 'text/css',
+  '.html': 'text/html',
+  '.js': 'application/javascript',
+  '.json': 'application/json',
+  '.svg': 'image/svg+xml',
+  '.wasm': 'application/wasm',
+};
+
+function getContentType(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  return mimeTypes[ext] ?? 'application/octet-stream';
+}
+
+async function trySendFile(res, filePath) {
   try {
     const data = await fs.readFile(filePath);
+    res.statusCode = 200;
+    res.setHeader('Content-Type', getContentType(filePath));
     res.end(data);
+    return true;
   } catch (err) {
-    res.statusCode = 404;
-    res.end('Not found');
+    if (err.code !== 'ENOENT') {
+      res.statusCode = 500;
+      res.end('Server error');
+      return true;
+    }
   }
+  return false;
+}
+
+const server = http.createServer(async (req, res) => {
+  const requestUrl = new URL(req.url, `http://${req.headers.host}`);
+  const pathname = decodeURIComponent(requestUrl.pathname);
+
+  if (pathname === '/' || pathname === '') {
+    if (await trySendFile(res, indexPath)) {
+      return;
+    }
+    res.statusCode = 500;
+    res.end('Index not found');
+    return;
+  }
+
+  const normalized = path
+    .normalize(pathname)
+    .replace(/^([.][.][/\\])+/, '')
+    .replace(/^[/\\]+/, '');
+
+  const repoCandidate = path.join(repoRoot, normalized);
+  if (repoCandidate.startsWith(repoRoot) && (await trySendFile(res, repoCandidate))) {
+    return;
+  }
+
+  const publicCandidate = path.join(publicDir, normalized);
+  if (publicCandidate.startsWith(publicDir) && (await trySendFile(res, publicCandidate))) {
+    return;
+  }
+
+  res.statusCode = 404;
+  res.end('Not found');
 });
 
 const port = process.env.PORT || 8080;

--- a/public/main.js
+++ b/public/main.js
@@ -1,11 +1,11 @@
-import '../editor/app/main.js';
-import AssetsPane from '../editor/panes/assets.js';
+import '/editor/app/main.js';
+import AssetsPane from '/editor/panes/assets.js';
 
 // Initialize the Assets pane in the editor UI.
 new AssetsPane();
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('service-worker.js');
+    navigator.serviceWorker.register('/service-worker.js').catch(() => {});
   });
 }

--- a/tools/pack/copy-static.js
+++ b/tools/pack/copy-static.js
@@ -2,10 +2,17 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { rimraf } from 'rimraf';
 
-const srcDir = path.resolve('public');
 const destDir = path.resolve('dist');
+const sources = [
+  { src: path.resolve('public'), dest: destDir },
+  { src: path.resolve('editor'), dest: path.join(destDir, 'editor') },
+  { src: path.resolve('engine'), dest: path.join(destDir, 'engine') },
+];
 
-rimraf.sync(destDir);
+function sanitizeRelative(base, target) {
+  const relative = path.relative(base, target);
+  return !relative.startsWith('..') && !path.isAbsolute(relative);
+}
 
 async function copy(src, dest) {
   const entries = await fs.readdir(src, { withFileTypes: true });
@@ -21,7 +28,18 @@ async function copy(src, dest) {
   }
 }
 
-copy(srcDir, destDir).catch(err => {
+async function main() {
+  rimraf.sync(destDir);
+
+  for (const { src, dest } of sources) {
+    if (!sanitizeRelative(process.cwd(), src)) {
+      throw new Error(`Refusing to copy from outside project root: ${src}`);
+    }
+    await copy(src, dest);
+  }
+}
+
+main().catch(err => {
   console.error(err);
   process.exit(1);
 });

--- a/tools/pack/serve-dist.js
+++ b/tools/pack/serve-dist.js
@@ -2,16 +2,65 @@ import http from 'http';
 import { promises as fs } from 'fs';
 import path from 'path';
 
-const base = path.resolve('dist');
-const server = http.createServer(async (req, res) => {
-  const filePath = path.join(base, req.url === '/' ? '/index.html' : req.url);
+const distRoot = path.resolve('dist');
+const indexPath = path.join(distRoot, 'index.html');
+
+const mimeTypes = {
+  '.css': 'text/css',
+  '.html': 'text/html',
+  '.js': 'application/javascript',
+  '.json': 'application/json',
+  '.svg': 'image/svg+xml',
+  '.wasm': 'application/wasm',
+};
+
+function getContentType(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  return mimeTypes[ext] ?? 'application/octet-stream';
+}
+
+async function trySendFile(res, filePath) {
   try {
     const data = await fs.readFile(filePath);
+    res.statusCode = 200;
+    res.setHeader('Content-Type', getContentType(filePath));
     res.end(data);
+    return true;
   } catch (err) {
-    res.statusCode = 404;
-    res.end('Not found');
+    if (err.code !== 'ENOENT') {
+      res.statusCode = 500;
+      res.end('Server error');
+      return true;
+    }
   }
+  return false;
+}
+
+const server = http.createServer(async (req, res) => {
+  const requestUrl = new URL(req.url, `http://${req.headers.host}`);
+  const pathname = decodeURIComponent(requestUrl.pathname);
+
+  if (pathname === '/' || pathname === '') {
+    if (await trySendFile(res, indexPath)) {
+      return;
+    }
+    res.statusCode = 500;
+    res.end('Index not found');
+    return;
+  }
+
+  const normalized = path
+    .normalize(pathname)
+    .replace(/^([.][.][/\\])+/, '')
+    .replace(/^[/\\]+/, '');
+
+  const candidate = path.join(distRoot, normalized);
+  if (candidate.startsWith(distRoot) && (await trySendFile(res, candidate))) {
+    return;
+  }
+
+  res.statusCode = 404;
+  res.end('Not found');
 });
 
 const port = process.env.PORT || 5000;


### PR DESCRIPTION
## Summary
- switch the public entrypoint to absolute module imports so the browser resolves editor modules correctly
- update the dev and dist servers to serve from the repository root with proper MIME types while keeping the public index fallback
- copy the editor and engine directories into the dist bundle during the static asset preparation step

## Testing
- npm run prepare:dist
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd892ed55c832caa122f98e84e8e06