### PR TITLE
Fix RunService timing for browser environments

### DIFF
--- a/engine/core/env.js
+++ b/engine/core/env.js
@@ -1,0 +1,7 @@
+// Browser-safe environment helpers. NO Node-only globals.
+export const nowMs = () => performance.now();
+
+// Detect "dev" heuristically (no bundler env). Keep it simple & robust.
+export const isDev =
+  (typeof import.meta !== "undefined" && import.meta.env && import.meta.env.MODE === "development") ||
+  (typeof location !== "undefined" && (location.hostname === "localhost" || location.hostname === "127.0.0.1"));

--- a/engine/core/index.js
+++ b/engine/core/index.js
@@ -2,7 +2,7 @@ import Lighting from '../services/Lighting.js';
 import CollectionService from '../services/CollectionService.js';
 import TweenService from '../services/TweenService.js';
 import UserInputService from '../services/UserInputService.js';
-import RunService from '../services/RunService.js';
+import { RunService } from '../services/RunService.js';
 import PhysicsService from '../services/PhysicsService.js';
 import { Signal } from './signal.js';
 import { isValidAttribute } from './types.js';
@@ -139,9 +139,7 @@ Object.defineProperty(userInputService, 'MouseDeltaSensitivity', {
 });
 Services.set('UserInputService', userInputService);
 
-const runService = new Instance('RunService');
-Object.assign(runService, new RunService());
-Services.set('RunService', runService);
+Services.set('RunService', RunService);
 
 const physicsService = new Instance('PhysicsService');
 Object.assign(physicsService, new PhysicsService());

--- a/engine/render/gpu/webgpu.js
+++ b/engine/render/gpu/webgpu.js
@@ -1,4 +1,3 @@
-import { GetService } from '../../core/index.js';
 import FrameGraph from '../framegraph/index.js';
 import ClearPass from '../passes/clearPass.js';
 import SkyPass from '../passes/skyPass.js';
@@ -8,6 +7,7 @@ import ACESPass from '../passes/acesPass.js';
 import FXAAPass from '../passes/fxaaPass.js';
 import Materials from '../materials/registry.js';
 import { setGPUAdapterName, updateFrameMetrics } from '../framegraph/stats.js';
+import { RunService } from '../../services/RunService.js';
 
 export async function initWebGPU(canvas) {
   if (!navigator.gpu) {
@@ -42,8 +42,6 @@ export async function initWebGPU(canvas) {
   frameGraph.addPass(fxaaPass);
   await frameGraph.init();
 
-  const runService = GetService('RunService');
-
   let last = performance.now() / 1000;
 
   function frame(ts) {
@@ -53,7 +51,9 @@ export async function initWebGPU(canvas) {
 
     updateFrameMetrics(dt);
 
-    runService._step(dt);
+    if (typeof RunService._step === 'function') {
+      RunService._step();
+    }
 
     const width = canvas.clientWidth * devicePixelRatio;
     const height = canvas.clientHeight * devicePixelRatio;
@@ -74,8 +74,6 @@ export async function initWebGPU(canvas) {
     }
 
     frameGraph.render();
-
-    runService._heartbeat(dt);
 
     requestAnimationFrame(frame);
   }

--- a/tests/ava/runservice.test.js
+++ b/tests/ava/runservice.test.js
@@ -1,16 +1,29 @@
 import test from 'ava';
-import { GetService } from '../../engine/core/index.js';
+import { RunService } from '../../engine/services/RunService.js';
 
-const RS = () => GetService('RunService');
+const createRunService = () => new RunService.constructor();
+
+function stepWithDt(rs, dtSeconds) {
+  const perf = globalThis.performance || (globalThis.performance = { now: () => Date.now() });
+  const originalNow = perf.now;
+  const last = 1000;
+  rs._last = last;
+  perf.now = () => last + dtSeconds * 1000;
+  try {
+    rs._step();
+  } finally {
+    perf.now = originalNow;
+  }
+}
 
 // Bind order by priority
 
 test('bind order by priority', t => {
-  const rs = RS();
+  const rs = createRunService();
   const order = [];
   rs.BindToRenderStep('a', 2, () => order.push('a'));
   rs.BindToRenderStep('b', 1, () => order.push('b'));
-  rs._step(0.016);
+  stepWithDt(rs, 0.016);
   t.deepEqual(order, ['b', 'a']);
   rs.UnbindFromRenderStep('a');
   rs.UnbindFromRenderStep('b');
@@ -19,23 +32,23 @@ test('bind order by priority', t => {
 // dt > 0
 
 test('dt greater than zero', t => {
-  const rs = RS();
+  const rs = createRunService();
   let dtVal = 0;
   rs.RenderStepped.Once(dt => {
     dtVal = dt;
   });
-  rs._step(0.033);
+  stepWithDt(rs, 0.033);
   t.true(dtVal > 0);
 });
 
 // unbind works
 
 test('unbind removes step', t => {
-  const rs = RS();
+  const rs = createRunService();
   const order = [];
   rs.BindToRenderStep('temp', 1, () => order.push('temp'));
   rs.UnbindFromRenderStep('temp');
-  rs._step(0.02);
+  stepWithDt(rs, 0.02);
   t.deepEqual(order, []);
 });
 


### PR DESCRIPTION
## Summary
- add a browser-safe env helper with `nowMs` and `isDev`
- rework RunService to use `performance.now()` and remove `process` references
- adjust WebGPU renderer, playmode runtime, and tests to call the new RunService API safely

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2ff8eda9c832c81c28a21b9003cbf