### PR TITLE
Embed sample glTF assets as data URIs

### DIFF
--- a/editor/panes/assets.js
+++ b/editor/panes/assets.js
@@ -1,9 +1,14 @@
 import AssetService from '../services/assets.js';
+import importGLTF from '../../engine/asset/gltf/importer.js';
+import { getWorkspace } from '../../engine/scene/workspace.js';
+import { tryGetDevice } from '../../engine/render/gpu/device.js';
 
 // Basic Asset Manager pane providing import and listing features.
 export default class AssetsPane {
   constructor(service = new AssetService()) {
     this.service = service;
+    this.workspace = getWorkspace();
+    this._setupUI();
   }
 
   // Import an array of File objects or paths.
@@ -23,5 +28,68 @@ export default class AssetsPane {
   // Get a logical URI for an asset suitable for runtime resolution.
   copyPath(asset) {
     return this.service.getURI(asset);
+  }
+
+  async importGLTF(url) {
+    if (!url) {
+      return null;
+    }
+    if (!tryGetDevice()) {
+      throw new Error('GPU device is not ready. Please wait for WebGPU initialization.');
+    }
+    await this.import(url);
+    const result = await importGLTF(url, { name: url.split('/').pop() });
+    console.info('[Assets] Imported glTF', url, result);
+    return result;
+  }
+
+  _setupUI() {
+    if (typeof document === 'undefined') {
+      return;
+    }
+    if (document.getElementById('asset-import-panel')) {
+      return;
+    }
+
+    const container = document.createElement('div');
+    container.id = 'asset-import-panel';
+    container.style.position = 'fixed';
+    container.style.bottom = '16px';
+    container.style.left = '16px';
+    container.style.display = 'flex';
+    container.style.flexDirection = 'column';
+    container.style.gap = '8px';
+    container.style.padding = '12px';
+    container.style.borderRadius = '12px';
+    container.style.background = 'rgba(20, 20, 20, 0.8)';
+    container.style.backdropFilter = 'blur(8px)';
+    container.style.boxShadow = '0 10px 25px rgba(0, 0, 0, 0.35)';
+    container.style.zIndex = '1001';
+
+    const button = document.createElement('button');
+    button.textContent = 'Import glTF';
+    button.style.border = 'none';
+    button.style.padding = '8px 16px';
+    button.style.borderRadius = '8px';
+    button.style.background = '#3498db';
+    button.style.color = '#fff';
+    button.style.fontWeight = '600';
+    button.style.cursor = 'pointer';
+
+    button.addEventListener('click', async () => {
+      const defaultPath = '/assets/sample/scene.gltf';
+      const url = prompt('Enter glTF URL', defaultPath);
+      if (!url) {
+        return;
+      }
+      try {
+        await this.importGLTF(url);
+      } catch (err) {
+        console.error('[Assets] Failed to import glTF', url, err);
+      }
+    });
+
+    container.appendChild(button);
+    document.body.appendChild(container);
   }
 }

--- a/engine/asset/gltf/importer.js
+++ b/engine/asset/gltf/importer.js
@@ -1,0 +1,383 @@
+import loadGLTF from './loader.js';
+import { getAccessorArray, isSRGBTextureSlot } from './utils.js';
+import Mesh from '../../render/mesh/mesh.js';
+import MeshInstance, { TransformNode } from '../../render/mesh/meshInstance.js';
+import Materials from '../../render/materials/registry.js';
+import { getDevice } from '../../render/gpu/device.js';
+import {
+  quaternionNormalize,
+  decomposeTRS,
+  quaternionFromEuler,
+} from '../../render/mesh/math.js';
+import { VERTEX_FLOATS } from '../../render/mesh/mesh.js';
+import { getWorkspace } from '../../scene/workspace.js';
+
+const DEFAULT_NORMAL = [0, 1, 0];
+const DEFAULT_TANGENT = [1, 0, 0, 1];
+const DEFAULT_UV = [0, 0];
+
+function warnIfUnsupportedTexCoord(info, label) {
+  if (info && typeof info.texCoord === 'number' && info.texCoord !== 0) {
+    console.warn(`[glTF] ${label} uses TEXCOORD_${info.texCoord}, only TEXCOORD_0 is currently supported.`);
+  }
+}
+
+function createVertexBufferData(gltf, primitive, buffers) {
+  const positionAccessor = primitive.attributes?.POSITION;
+  if (typeof positionAccessor !== 'number') {
+    throw new Error('Primitive is missing POSITION attribute');
+  }
+  const positions = getAccessorArray(gltf, positionAccessor, buffers, { forceFloat: true });
+  const vertexCount = positions.length / 3;
+
+  const normalsAccessor = primitive.attributes?.NORMAL;
+  const normals = typeof normalsAccessor === 'number'
+    ? getAccessorArray(gltf, normalsAccessor, buffers, { forceFloat: true })
+    : new Float32Array(vertexCount * 3).fill(0);
+  if (normalsAccessor == null) {
+    for (let i = 0; i < vertexCount; i += 1) {
+      normals[i * 3 + 0] = DEFAULT_NORMAL[0];
+      normals[i * 3 + 1] = DEFAULT_NORMAL[1];
+      normals[i * 3 + 2] = DEFAULT_NORMAL[2];
+    }
+  }
+
+  const tangentsAccessor = primitive.attributes?.TANGENT;
+  const tangents = typeof tangentsAccessor === 'number'
+    ? getAccessorArray(gltf, tangentsAccessor, buffers, { forceFloat: true })
+    : new Float32Array(vertexCount * 4).fill(0);
+  if (tangentsAccessor == null) {
+    for (let i = 0; i < vertexCount; i += 1) {
+      tangents[i * 4 + 0] = DEFAULT_TANGENT[0];
+      tangents[i * 4 + 1] = DEFAULT_TANGENT[1];
+      tangents[i * 4 + 2] = DEFAULT_TANGENT[2];
+      tangents[i * 4 + 3] = DEFAULT_TANGENT[3];
+    }
+  }
+
+  const texCoordAccessor = primitive.attributes?.TEXCOORD_0;
+  const texCoords = typeof texCoordAccessor === 'number'
+    ? getAccessorArray(gltf, texCoordAccessor, buffers, { forceFloat: true })
+    : new Float32Array(vertexCount * 2).fill(0);
+  if (texCoordAccessor == null) {
+    for (let i = 0; i < vertexCount; i += 1) {
+      texCoords[i * 2 + 0] = DEFAULT_UV[0];
+      texCoords[i * 2 + 1] = DEFAULT_UV[1];
+    }
+  }
+
+  const vertexData = new Float32Array(vertexCount * VERTEX_FLOATS);
+  for (let i = 0; i < vertexCount; i += 1) {
+    const offset = i * VERTEX_FLOATS;
+    vertexData[offset + 0] = positions[i * 3 + 0];
+    vertexData[offset + 1] = positions[i * 3 + 1];
+    vertexData[offset + 2] = positions[i * 3 + 2];
+
+    vertexData[offset + 3] = normals[i * 3 + 0];
+    vertexData[offset + 4] = normals[i * 3 + 1];
+    vertexData[offset + 5] = normals[i * 3 + 2];
+
+    vertexData[offset + 6] = tangents[i * 4 + 0];
+    vertexData[offset + 7] = tangents[i * 4 + 1];
+    vertexData[offset + 8] = tangents[i * 4 + 2];
+    vertexData[offset + 9] = tangents[i * 4 + 3];
+
+    vertexData[offset + 10] = texCoords[i * 2 + 0];
+    vertexData[offset + 11] = texCoords[i * 2 + 1];
+  }
+
+  return { vertexData, vertexCount };
+}
+
+function getIndices(gltf, primitive, buffers) {
+  if (typeof primitive.indices !== 'number') {
+    const vertexCount = getAccessorArray(gltf, primitive.attributes.POSITION, buffers, { forceFloat: true }).length / 3;
+    const indices = vertexCount > 65535 ? new Uint32Array(vertexCount) : new Uint16Array(vertexCount);
+    for (let i = 0; i < vertexCount; i += 1) {
+      indices[i] = i;
+    }
+    return indices;
+  }
+  const data = getAccessorArray(gltf, primitive.indices, buffers);
+  if (data instanceof Uint8Array || data instanceof Uint16Array || data instanceof Uint32Array) {
+    return data;
+  }
+  if (data instanceof Float32Array) {
+    const result = data.length > 65535 ? new Uint32Array(data.length) : new Uint16Array(data.length);
+    for (let i = 0; i < data.length; i += 1) {
+      result[i] = data[i];
+    }
+    return result;
+  }
+  return new Uint32Array(data);
+}
+
+function convertWrap(mode) {
+  switch (mode) {
+    case 33071: return 'clamp-to-edge';
+    case 33648: return 'mirror-repeat';
+    case 10497: return 'repeat';
+    default: return 'repeat';
+  }
+}
+
+function convertMagFilter(filter) {
+  if (filter === 9728) return 'nearest';
+  if (filter === 9729) return 'linear';
+  return 'linear';
+}
+
+function convertMinFilter(filter) {
+  switch (filter) {
+    case 9728: return { minFilter: 'nearest', mipmapFilter: 'nearest' };
+    case 9729: return { minFilter: 'linear', mipmapFilter: 'nearest' };
+    case 9984: return { minFilter: 'nearest', mipmapFilter: 'nearest' };
+    case 9985: return { minFilter: 'linear', mipmapFilter: 'nearest' };
+    case 9986: return { minFilter: 'nearest', mipmapFilter: 'linear' };
+    case 9987: return { minFilter: 'linear', mipmapFilter: 'linear' };
+    default: return { minFilter: 'linear', mipmapFilter: 'linear' };
+  }
+}
+
+function getSampler(device, gltf, samplerCache, samplerIndex) {
+  if (typeof samplerIndex !== 'number') {
+    if (!samplerCache.has('default')) {
+      samplerCache.set('default', device.createSampler({
+        addressModeU: 'repeat',
+        addressModeV: 'repeat',
+        magFilter: 'linear',
+        minFilter: 'linear',
+        mipmapFilter: 'linear',
+      }));
+    }
+    return samplerCache.get('default');
+  }
+  if (samplerCache.has(samplerIndex)) {
+    return samplerCache.get(samplerIndex);
+  }
+  const samplerDef = gltf.samplers?.[samplerIndex] || {};
+  const { minFilter, mipmapFilter } = convertMinFilter(samplerDef.minFilter);
+  const sampler = device.createSampler({
+    addressModeU: convertWrap(samplerDef.wrapS),
+    addressModeV: convertWrap(samplerDef.wrapT),
+    magFilter: convertMagFilter(samplerDef.magFilter),
+    minFilter,
+    mipmapFilter,
+  });
+  samplerCache.set(samplerIndex, sampler);
+  return sampler;
+}
+
+function createTextureView(device, image, srgb) {
+  const format = srgb ? 'rgba8unorm-srgb' : 'rgba8unorm';
+  const texture = device.createTexture({
+    size: { width: image.width, height: image.height, depthOrArrayLayers: 1 },
+    format,
+    usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
+  });
+  device.queue.copyExternalImageToTexture(
+    { source: image },
+    { texture },
+    [image.width, image.height],
+  );
+  return texture.createView();
+}
+
+function getTextureResource(device, gltf, textureIndex, images, samplerCache, textureCache, slot) {
+  if (typeof textureIndex !== 'number') {
+    return { texture: null, sampler: null };
+  }
+  const key = `${textureIndex}:${slot}`;
+  let view = textureCache.get(key);
+  if (!view) {
+    const textureDef = gltf.textures?.[textureIndex];
+    if (!textureDef || typeof textureDef.source !== 'number') {
+      return { texture: null, sampler: null };
+    }
+    const image = images[textureDef.source]?.bitmap;
+    if (!image) {
+      return { texture: null, sampler: null };
+    }
+    const srgb = isSRGBTextureSlot(slot);
+    view = createTextureView(device, image, srgb);
+    textureCache.set(key, view);
+  }
+  const textureDef = gltf.textures?.[textureIndex];
+  const sampler = getSampler(device, gltf, samplerCache, textureDef?.sampler);
+  return { texture: view, sampler };
+}
+
+function createMaterial(device, gltf, materialIndex, images, samplerCache, textureCache) {
+  const materialDef = gltf.materials?.[materialIndex];
+  if (!materialDef) {
+    return Materials.createStandard();
+  }
+  const params = {
+    color: materialDef.pbrMetallicRoughness?.baseColorFactor,
+    roughness: materialDef.pbrMetallicRoughness?.roughnessFactor,
+    metalness: materialDef.pbrMetallicRoughness?.metallicFactor,
+    emissive: materialDef.emissiveFactor,
+    occlusionStrength: materialDef.occlusionTexture?.strength,
+  };
+
+  const baseColorInfo = materialDef.pbrMetallicRoughness?.baseColorTexture;
+  if (baseColorInfo) {
+    warnIfUnsupportedTexCoord(baseColorInfo, 'baseColorTexture');
+    const resource = getTextureResource(device, gltf, baseColorInfo.index, images, samplerCache, textureCache, 'baseColor');
+    params.albedoTexture = resource.texture;
+    params.albedoSampler = resource.sampler;
+  }
+
+  const metallicRoughnessInfo = materialDef.pbrMetallicRoughness?.metallicRoughnessTexture;
+  if (metallicRoughnessInfo) {
+    warnIfUnsupportedTexCoord(metallicRoughnessInfo, 'metallicRoughnessTexture');
+    const resource = getTextureResource(device, gltf, metallicRoughnessInfo.index, images, samplerCache, textureCache, 'metallicRoughness');
+    params.metallicRoughnessTexture = resource.texture;
+    params.metallicRoughnessSampler = resource.sampler;
+  }
+
+  const normalInfo = materialDef.normalTexture;
+  if (normalInfo) {
+    warnIfUnsupportedTexCoord(normalInfo, 'normalTexture');
+    const resource = getTextureResource(device, gltf, normalInfo.index, images, samplerCache, textureCache, 'normal');
+    params.normalTexture = resource.texture;
+    params.normalSampler = resource.sampler;
+  }
+
+  const occlusionInfo = materialDef.occlusionTexture;
+  if (occlusionInfo) {
+    warnIfUnsupportedTexCoord(occlusionInfo, 'occlusionTexture');
+    const resource = getTextureResource(device, gltf, occlusionInfo.index, images, samplerCache, textureCache, 'occlusion');
+    params.occlusionTexture = resource.texture;
+    params.occlusionSampler = resource.sampler;
+  }
+
+  const emissiveInfo = materialDef.emissiveTexture;
+  if (emissiveInfo) {
+    warnIfUnsupportedTexCoord(emissiveInfo, 'emissiveTexture');
+    const resource = getTextureResource(device, gltf, emissiveInfo.index, images, samplerCache, textureCache, 'emissive');
+    params.emissiveTexture = resource.texture;
+    params.emissiveSampler = resource.sampler;
+  }
+
+  return Materials.createStandard(params);
+}
+
+function createMesh(device, gltf, meshDef, buffers, materialCache, materialIdForPrimitive) {
+  const primitives = [];
+  for (const primitive of meshDef.primitives || []) {
+    if (primitive.mode != null && primitive.mode !== 4) {
+      console.warn('[glTF] Unsupported primitive mode', primitive.mode, 'defaulting to TRIANGLES');
+    }
+    const { vertexData } = createVertexBufferData(gltf, primitive, buffers);
+    const indices = getIndices(gltf, primitive, buffers);
+    const materialIndex = typeof primitive.material === 'number' ? primitive.material : null;
+    let materialId = null;
+    if (materialIndex != null) {
+      if (!materialCache.has(materialIndex)) {
+        materialCache.set(materialIndex, materialIdForPrimitive(materialIndex));
+      }
+      materialId = materialCache.get(materialIndex);
+    } else {
+      if (!materialCache.has('default')) {
+        materialCache.set('default', Materials.createStandard());
+      }
+      materialId = materialCache.get('default');
+    }
+    primitives.push({ vertexData, indexData: indices, materialId });
+  }
+  return new Mesh(device, primitives);
+}
+
+function applyNodeTransform(node, nodeDef) {
+  let translation = nodeDef.translation ? [...nodeDef.translation] : [0, 0, 0];
+  let rotation = nodeDef.rotation ? quaternionNormalize(new Float32Array(nodeDef.rotation)) : quaternionFromEuler({ x: 0, y: 0, z: 0 });
+  let scale = nodeDef.scale ? [...nodeDef.scale] : [1, 1, 1];
+
+  if (Array.isArray(nodeDef.matrix)) {
+    const matrix = new Float32Array(nodeDef.matrix);
+    const { translation: t, rotation: r, scale: s } = decomposeTRS(matrix);
+    translation = t;
+    rotation = r;
+    scale = s;
+  }
+
+  node.setProperty('Position', { x: translation[0], y: translation[1], z: translation[2] });
+  node.setProperty('Scale', { x: scale[0], y: scale[1], z: scale[2] });
+  node.setRotationQuaternion(rotation, true);
+}
+
+function buildNodeGraph(device, gltf, nodeIndex, buffers, meshCache, materialCache, images, samplerCache, textureCache, materialIdForPrimitive) {
+  const nodeDef = gltf.nodes?.[nodeIndex];
+  if (!nodeDef) {
+    return null;
+  }
+
+  let instance;
+  if (typeof nodeDef.mesh === 'number') {
+    if (!meshCache.has(nodeDef.mesh)) {
+      const meshDef = gltf.meshes?.[nodeDef.mesh];
+      if (!meshDef) {
+        return null;
+      }
+      const mesh = createMesh(device, gltf, meshDef, buffers, materialCache, materialIdForPrimitive);
+      meshCache.set(nodeDef.mesh, mesh);
+    }
+    instance = new MeshInstance(meshCache.get(nodeDef.mesh));
+  } else {
+    instance = new TransformNode('ModelNode');
+  }
+
+  instance.Name = nodeDef.name || instance.Name;
+  applyNodeTransform(instance, nodeDef);
+
+  for (const childIndex of nodeDef.children || []) {
+    const child = buildNodeGraph(device, gltf, childIndex, buffers, meshCache, materialCache, images, samplerCache, textureCache, materialIdForPrimitive);
+    if (child) {
+      child.Parent = instance;
+    }
+  }
+
+  return instance;
+}
+
+export async function importGLTF(source, options = {}) {
+  const device = getDevice();
+  const asset = await loadGLTF(source, options);
+  const { gltf, buffers, images } = asset;
+
+  const materialCache = new Map();
+  const samplerCache = new Map();
+  const textureCache = new Map();
+  const meshCache = new Map();
+
+  const materialIdForPrimitive = (materialIndex) => createMaterial(device, gltf, materialIndex, images, samplerCache, textureCache);
+
+  const sceneIndex = options.scene ?? gltf.scene ?? 0;
+  const sceneDef = gltf.scenes?.[sceneIndex];
+  if (!sceneDef) {
+    throw new Error(`Scene index ${sceneIndex} not found in glTF`);
+  }
+
+  const root = new TransformNode('Model');
+  root.Name = options.name || sceneDef.name || 'Model';
+
+  for (const nodeIndex of sceneDef.nodes || []) {
+    const node = buildNodeGraph(device, gltf, nodeIndex, buffers, meshCache, materialCache, images, samplerCache, textureCache, materialIdForPrimitive);
+    if (node) {
+      node.Parent = root;
+    }
+  }
+
+  const workspace = getWorkspace();
+  root.Parent = workspace;
+
+  return {
+    root,
+    meshes: Array.from(meshCache.values()),
+    materials: Array.from(new Set(materialCache.values())),
+    asset,
+  };
+}
+
+export default importGLTF;

--- a/engine/asset/gltf/loader.js
+++ b/engine/asset/gltf/loader.js
@@ -1,0 +1,177 @@
+import { resolveUri } from './utils.js';
+
+const DATA_URI_REGEX = /^data:([^;,]*)(;base64)?,([\s\S]*)$/i;
+
+function getBaseUri(source) {
+  if (!source) {
+    return '';
+  }
+  const url = String(source);
+  const idx = url.lastIndexOf('/');
+  if (idx === -1) {
+    return '';
+  }
+  return url.slice(0, idx + 1);
+}
+
+function decodeBase64(base64) {
+  if (typeof atob === 'function') {
+    const binary = atob(base64);
+    const length = binary.length;
+    const bytes = new Uint8Array(length);
+    for (let i = 0; i < length; i += 1) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  }
+  if (typeof Buffer === 'function') {
+    const buffer = Buffer.from(base64, 'base64');
+    return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+  }
+  throw new Error('Base64 decoding is not supported in this environment');
+}
+
+function decodeTextData(data) {
+  const decoded = decodeURIComponent(data);
+  const length = decoded.length;
+  const bytes = new Uint8Array(length);
+  for (let i = 0; i < length; i += 1) {
+    bytes[i] = decoded.charCodeAt(i) & 0xff;
+  }
+  return bytes;
+}
+
+function parseDataUri(uri) {
+  const match = DATA_URI_REGEX.exec(uri);
+  if (!match) {
+    return null;
+  }
+  const mimeType = match[1] || 'application/octet-stream';
+  const isBase64 = Boolean(match[2]);
+  const dataPart = match[3] || '';
+  const bytes = isBase64 ? decodeBase64(dataPart) : decodeTextData(dataPart);
+  return { mimeType, bytes, buffer: bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) };
+}
+
+async function fetchArrayBuffer(fetchFn, uri) {
+  if (typeof uri === 'string' && /^data:/i.test(uri)) {
+    const parsed = parseDataUri(uri);
+    if (!parsed) {
+      throw new Error(`Failed to parse data URI: ${uri}`);
+    }
+    return parsed.buffer;
+  }
+  const res = await fetchFn(uri);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${uri}: ${res.status} ${res.statusText}`);
+  }
+  return await res.arrayBuffer();
+}
+
+async function fetchJSON(fetchFn, uri) {
+  const res = await fetchFn(uri);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${uri}: ${res.status} ${res.statusText}`);
+  }
+  return await res.json();
+}
+
+async function loadImage(fetchFn, uri) {
+  if (typeof uri === 'string' && /^data:/i.test(uri)) {
+    const parsed = parseDataUri(uri);
+    if (!parsed) {
+      throw new Error(`Failed to parse data URI: ${uri}`);
+    }
+    const blob = new Blob([parsed.buffer], { type: parsed.mimeType });
+    if (typeof createImageBitmap === 'function') {
+      return await createImageBitmap(blob);
+    }
+    return await new Promise((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => resolve(img);
+      img.onerror = reject;
+      img.src = uri;
+    });
+  }
+  const res = await fetchFn(uri);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${uri}: ${res.status} ${res.statusText}`);
+  }
+  const blob = await res.blob();
+  if (typeof createImageBitmap === 'function') {
+    return await createImageBitmap(blob);
+  }
+  return await new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = reject;
+    img.src = URL.createObjectURL(blob);
+  });
+}
+
+function viewToBlob(gltf, imageDef, buffers) {
+  const bufferView = gltf.bufferViews?.[imageDef.bufferView];
+  if (!bufferView) {
+    throw new Error(`BufferView ${imageDef.bufferView} missing for embedded image`);
+  }
+  const buffer = buffers?.[bufferView.buffer];
+  if (!buffer) {
+    throw new Error(`Buffer ${bufferView.buffer} missing for embedded image`);
+  }
+  const offset = bufferView.byteOffset || 0;
+  const length = bufferView.byteLength || buffer.byteLength - offset;
+  const slice = buffer.slice(offset, offset + length);
+  return new Blob([slice], { type: imageDef.mimeType || 'application/octet-stream' });
+}
+
+async function loadImageFromBufferView(gltf, imageDef, buffers) {
+  const blob = viewToBlob(gltf, imageDef, buffers);
+  if (typeof createImageBitmap === 'function') {
+    return await createImageBitmap(blob);
+  }
+  return await new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = reject;
+    img.src = URL.createObjectURL(blob);
+  });
+}
+
+export async function loadGLTF(source, options = {}) {
+  const fetchFn = options.fetch ?? (typeof fetch === 'function' ? fetch.bind(globalThis) : null);
+  if (!fetchFn) {
+    throw new Error('Global fetch() is not available; provide options.fetch');
+  }
+
+  if (typeof source !== 'string') {
+    throw new Error('loadGLTF currently supports string URLs only');
+  }
+
+  const baseUri = options.baseUri || getBaseUri(source);
+  const gltf = await fetchJSON(fetchFn, source);
+
+  const buffers = await Promise.all((gltf.buffers || []).map(async (bufferDef, index) => {
+    if (!bufferDef.uri) {
+      throw new Error(`Buffer #${index} is missing a URI. GLB files are not supported yet.`);
+    }
+    const uri = resolveUri(baseUri, bufferDef.uri);
+    return await fetchArrayBuffer(fetchFn, uri);
+  }));
+
+  const images = await Promise.all((gltf.images || []).map(async imageDef => {
+    if (typeof imageDef.bufferView === 'number') {
+      const bitmap = await loadImageFromBufferView(gltf, imageDef, buffers);
+      return { bitmap, mimeType: imageDef.mimeType || 'image/png', name: imageDef.name || null };
+    }
+    if (!imageDef.uri) {
+      throw new Error('Image is missing both uri and bufferView');
+    }
+    const uri = resolveUri(baseUri, imageDef.uri);
+    const bitmap = await loadImage(fetchFn, uri);
+    return { bitmap, mimeType: imageDef.mimeType || 'image/png', name: imageDef.name || null, uri };
+  }));
+
+  return { gltf, buffers, images, baseUri };
+}
+
+export default loadGLTF;

--- a/engine/asset/gltf/utils.js
+++ b/engine/asset/gltf/utils.js
@@ -1,0 +1,147 @@
+const COMPONENT_INFO = {
+  5120: { ctor: Int8Array, size: 1, normalized: { min: -128, max: 127 } }, // BYTE
+  5121: { ctor: Uint8Array, size: 1, normalized: { min: 0, max: 255 } }, // UNSIGNED_BYTE
+  5122: { ctor: Int16Array, size: 2, normalized: { min: -32768, max: 32767 } }, // SHORT
+  5123: { ctor: Uint16Array, size: 2, normalized: { min: 0, max: 65535 } }, // UNSIGNED_SHORT
+  5125: { ctor: Uint32Array, size: 4, normalized: { min: 0, max: 4294967295 } }, // UNSIGNED_INT
+  5126: { ctor: Float32Array, size: 4 }, // FLOAT
+};
+
+const TYPE_COMPONENTS = {
+  SCALAR: 1,
+  VEC2: 2,
+  VEC3: 3,
+  VEC4: 4,
+  MAT2: 4,
+  MAT3: 9,
+  MAT4: 16,
+};
+
+function getComponentInfo(componentType) {
+  const info = COMPONENT_INFO[componentType];
+  if (!info) {
+    throw new Error(`Unsupported glTF component type ${componentType}`);
+  }
+  return info;
+}
+
+function getComponentCount(type) {
+  const count = TYPE_COMPONENTS[type];
+  if (!count) {
+    throw new Error(`Unsupported glTF accessor type ${type}`);
+  }
+  return count;
+}
+
+function readComponent(dataView, byteOffset, componentType) {
+  switch (componentType) {
+    case 5120:
+      return dataView.getInt8(byteOffset);
+    case 5121:
+      return dataView.getUint8(byteOffset);
+    case 5122:
+      return dataView.getInt16(byteOffset, true);
+    case 5123:
+      return dataView.getUint16(byteOffset, true);
+    case 5125:
+      return dataView.getUint32(byteOffset, true);
+    case 5126:
+      return dataView.getFloat32(byteOffset, true);
+    default:
+      throw new Error(`Unsupported component type ${componentType}`);
+  }
+}
+
+function normalizeValue(value, componentType) {
+  const info = COMPONENT_INFO[componentType];
+  if (!info || !info.normalized) {
+    return value;
+  }
+  const { min, max } = info.normalized;
+  if (min < 0) {
+    const range = max;
+    const v = value / range;
+    return Math.max(-1, Math.min(1, v));
+  }
+  const range = max === 0 ? 1 : max;
+  return Math.max(0, Math.min(1, value / range));
+}
+
+export function getAccessorArray(gltf, accessorIndex, buffers, { forceFloat = false } = {}) {
+  const accessor = gltf.accessors?.[accessorIndex];
+  if (!accessor) {
+    throw new Error(`Accessor ${accessorIndex} not found`);
+  }
+  if (typeof accessor.bufferView !== 'number') {
+    throw new Error('Sparse accessors without bufferView are not supported');
+  }
+  const bufferView = gltf.bufferViews?.[accessor.bufferView];
+  if (!bufferView) {
+    throw new Error(`BufferView ${accessor.bufferView} not found`);
+  }
+  const buffer = buffers?.[bufferView.buffer];
+  if (!buffer) {
+    throw new Error(`Buffer ${bufferView.buffer} not loaded`);
+  }
+
+  const componentInfo = getComponentInfo(accessor.componentType);
+  const componentCount = getComponentCount(accessor.type);
+  const count = accessor.count || 0;
+  const byteOffset = (bufferView.byteOffset || 0) + (accessor.byteOffset || 0);
+  const stride = bufferView.byteStride || componentInfo.size * componentCount;
+  const normalized = Boolean(accessor.normalized);
+  const useFloat = forceFloat || componentInfo.ctor === Float32Array;
+
+  if (count === 0) {
+    return useFloat ? new Float32Array(0) : new componentInfo.ctor(0);
+  }
+
+  if (stride === componentInfo.size * componentCount && !normalized && !forceFloat && componentInfo.ctor !== Float32Array) {
+    return new componentInfo.ctor(buffer, byteOffset, count * componentCount);
+  }
+
+  const elementStride = stride;
+  const dataViewLength = elementStride * (count - 1) + componentInfo.size * componentCount;
+  const dataView = new DataView(buffer, byteOffset, dataViewLength);
+  const output = useFloat ? new Float32Array(count * componentCount) : new componentInfo.ctor(count * componentCount);
+
+  for (let i = 0; i < count; i += 1) {
+    for (let c = 0; c < componentCount; c += 1) {
+      const offset = i * elementStride + c * componentInfo.size;
+      let value = readComponent(dataView, offset, accessor.componentType);
+      if (normalized) {
+        value = normalizeValue(value, accessor.componentType);
+      } else if (useFloat && componentInfo.ctor !== Float32Array) {
+        value = Number(value);
+      }
+      output[i * componentCount + c] = value;
+    }
+  }
+
+  return output;
+}
+
+export function isSRGBTextureSlot(slot) {
+  return slot === 'baseColor' || slot === 'emissive';
+}
+
+export function resolveUri(baseUri, target) {
+  if (!target) {
+    return baseUri;
+  }
+  if (/^https?:\/\//i.test(target) || /^data:/i.test(target)) {
+    return target;
+  }
+  if (!baseUri) {
+    return target;
+  }
+  try {
+    const url = new URL(target, baseUri);
+    return url.toString();
+  } catch {
+    if (baseUri.endsWith('/')) {
+      return `${baseUri}${target}`;
+    }
+    return `${baseUri}/${target}`;
+  }
+}

--- a/engine/render/gpu/device.js
+++ b/engine/render/gpu/device.js
@@ -1,0 +1,16 @@
+let device = null;
+
+export function setDevice(gpuDevice) {
+  device = gpuDevice || null;
+}
+
+export function getDevice() {
+  if (!device) {
+    throw new Error('GPU device has not been initialized. Call initWebGPU() first.');
+  }
+  return device;
+}
+
+export function tryGetDevice() {
+  return device;
+}

--- a/engine/render/gpu/webgpu.js
+++ b/engine/render/gpu/webgpu.js
@@ -8,6 +8,7 @@ import FXAAPass from '../passes/fxaaPass.js';
 import Materials from '../materials/registry.js';
 import { setGPUAdapterName, updateFrameMetrics } from '../framegraph/stats.js';
 import { RunService } from '../../services/RunService.js';
+import { setDevice } from './device.js';
 
 export async function initWebGPU(canvas) {
   if (!navigator.gpu) {
@@ -21,6 +22,7 @@ export async function initWebGPU(canvas) {
   }
   setGPUAdapterName(adapter.name || 'Unknown GPU');
   const device = await adapter.requestDevice();
+  setDevice(device);
   const context = canvas.getContext('webgpu');
   const format = navigator.gpu.getPreferredCanvasFormat();
   context.configure({ device, format });
@@ -31,7 +33,7 @@ export async function initWebGPU(canvas) {
   const frameGraph = new FrameGraph(device, context);
   const clearPass = new ClearPass(device, () => hdrTarget.getView());
   const skyPass = new SkyPass(device, 'rgba16float', () => hdrTarget.getView());
-  const meshPass = new MeshPass(device, 'rgba16float', () => hdrTarget.getView());
+  const meshPass = new MeshPass(device, 'rgba16float', () => hdrTarget.getView(), () => hdrTarget.getSize());
   const acesPass = new ACESPass(device, hdrTarget, 'rgba16float');
   const fxaaPass = new FXAAPass(device, acesPass, format);
 

--- a/engine/render/materials/material.js
+++ b/engine/render/materials/material.js
@@ -1,6 +1,8 @@
 const DEFAULT_COLOR = [1, 1, 1, 1];
 const DEFAULT_ROUGHNESS = 1.0;
 const DEFAULT_METALNESS = 0.0;
+const DEFAULT_EMISSIVE = [0, 0, 0];
+const DEFAULT_OCCLUSION = 1.0;
 
 function toVec4Color(input) {
   if (!input) {
@@ -23,11 +25,15 @@ export class StandardPBRMaterial {
     this.color = toVec4Color(params.color);
     this.roughness = params.roughness ?? DEFAULT_ROUGHNESS;
     this.metalness = params.metalness ?? DEFAULT_METALNESS;
+    this.emissive = new Float32Array([...(params.emissive || DEFAULT_EMISSIVE), 0]);
+    this.occlusionStrength = params.occlusionStrength ?? DEFAULT_OCCLUSION;
 
     this.maps = {
       albedo: { texture: null, sampler: null },
+      metallicRoughness: { texture: null, sampler: null },
       normal: { texture: null, sampler: null },
-      orm: { texture: null, sampler: null }
+      occlusion: { texture: null, sampler: null },
+      emissive: { texture: null, sampler: null },
     };
 
     this.update(params);
@@ -43,6 +49,14 @@ export class StandardPBRMaterial {
     if (Object.prototype.hasOwnProperty.call(params, 'metalness') && typeof params.metalness === 'number') {
       this.metalness = params.metalness;
     }
+    if (Object.prototype.hasOwnProperty.call(params, 'emissive')) {
+      const arr = Array.from(params.emissive ?? DEFAULT_EMISSIVE);
+      while (arr.length < 3) arr.push(0);
+      this.emissive = new Float32Array([...arr.slice(0, 3), 0]);
+    }
+    if (Object.prototype.hasOwnProperty.call(params, 'occlusionStrength') && typeof params.occlusionStrength === 'number') {
+      this.occlusionStrength = params.occlusionStrength;
+    }
 
     if (Object.prototype.hasOwnProperty.call(params, 'albedoTexture')) {
       this.maps.albedo.texture = params.albedoTexture;
@@ -50,27 +64,43 @@ export class StandardPBRMaterial {
     if (Object.prototype.hasOwnProperty.call(params, 'albedoSampler')) {
       this.maps.albedo.sampler = params.albedoSampler;
     }
+    if (Object.prototype.hasOwnProperty.call(params, 'metallicRoughnessTexture')) {
+      this.maps.metallicRoughness.texture = params.metallicRoughnessTexture;
+    }
+    if (Object.prototype.hasOwnProperty.call(params, 'metallicRoughnessSampler')) {
+      this.maps.metallicRoughness.sampler = params.metallicRoughnessSampler;
+    }
     if (Object.prototype.hasOwnProperty.call(params, 'normalTexture')) {
       this.maps.normal.texture = params.normalTexture;
     }
     if (Object.prototype.hasOwnProperty.call(params, 'normalSampler')) {
       this.maps.normal.sampler = params.normalSampler;
     }
-    if (Object.prototype.hasOwnProperty.call(params, 'ormTexture')) {
-      this.maps.orm.texture = params.ormTexture;
+    if (Object.prototype.hasOwnProperty.call(params, 'occlusionTexture')) {
+      this.maps.occlusion.texture = params.occlusionTexture;
     }
-    if (Object.prototype.hasOwnProperty.call(params, 'ormSampler')) {
-      this.maps.orm.sampler = params.ormSampler;
+    if (Object.prototype.hasOwnProperty.call(params, 'occlusionSampler')) {
+      this.maps.occlusion.sampler = params.occlusionSampler;
+    }
+    if (Object.prototype.hasOwnProperty.call(params, 'emissiveTexture')) {
+      this.maps.emissive.texture = params.emissiveTexture;
+    }
+    if (Object.prototype.hasOwnProperty.call(params, 'emissiveSampler')) {
+      this.maps.emissive.sampler = params.emissiveSampler;
     }
   }
 
   toUniformArray(target) {
-    const out = target || new Float32Array(8);
+    const out = target || new Float32Array(12);
     out.set(this.color, 0);
-    out[4] = this.roughness;
-    out[5] = this.metalness;
-    out[6] = 0.0;
-    out[7] = 0.0;
+    out[4] = this.emissive[0];
+    out[5] = this.emissive[1];
+    out[6] = this.emissive[2];
+    out[7] = this.occlusionStrength;
+    out[8] = this.roughness;
+    out[9] = this.metalness;
+    out[10] = 0.0;
+    out[11] = 0.0;
     return out;
   }
 }
@@ -79,10 +109,16 @@ export const DEFAULT_STANDARD_PBR_PARAMS = {
   color: DEFAULT_COLOR,
   roughness: DEFAULT_ROUGHNESS,
   metalness: DEFAULT_METALNESS,
+  emissive: DEFAULT_EMISSIVE,
+  occlusionStrength: DEFAULT_OCCLUSION,
   albedoTexture: null,
   albedoSampler: null,
+  metallicRoughnessTexture: null,
+  metallicRoughnessSampler: null,
   normalTexture: null,
   normalSampler: null,
-  ormTexture: null,
-  ormSampler: null
+  occlusionTexture: null,
+  occlusionSampler: null,
+  emissiveTexture: null,
+  emissiveSampler: null,
 };

--- a/engine/render/materials/pbrStandard.wgsl
+++ b/engine/render/materials/pbrStandard.wgsl
@@ -1,0 +1,64 @@
+struct SceneUniform {
+  viewProj : mat4x4<f32>,
+  view : mat4x4<f32>,
+  cameraPos : vec4<f32>,
+};
+
+struct MaterialUniform {
+  baseColorFactor : vec4<f32>,
+  emissiveOcclusion : vec4<f32>,
+  params : vec4<f32>,
+};
+
+struct InstanceUniform {
+  model : mat4x4<f32>,
+  normal : mat4x4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> scene : SceneUniform;
+
+@group(1) @binding(0) var<uniform> material : MaterialUniform;
+@group(1) @binding(1) var baseColorTexture : texture_2d<f32>;
+@group(1) @binding(2) var baseColorSampler : sampler;
+@group(1) @binding(3) var metallicRoughnessTexture : texture_2d<f32>;
+@group(1) @binding(4) var metallicRoughnessSampler : sampler;
+@group(1) @binding(5) var normalTexture : texture_2d<f32>;
+@group(1) @binding(6) var normalSampler : sampler;
+@group(1) @binding(7) var occlusionTexture : texture_2d<f32>;
+@group(1) @binding(8) var occlusionSampler : sampler;
+@group(1) @binding(9) var emissiveTexture : texture_2d<f32>;
+@group(1) @binding(10) var emissiveSampler : sampler;
+
+@group(2) @binding(0) var<uniform> instanceUniform : InstanceUniform;
+
+struct VertexInput {
+  @location(0) position : vec3<f32>,
+  @location(1) normal : vec3<f32>,
+  @location(2) tangent : vec4<f32>,
+  @location(3) uv : vec2<f32>,
+};
+
+struct VertexOutput {
+  @builtin(position) position : vec4<f32>,
+  @location(0) worldPos : vec3<f32>,
+  @location(1) normal : vec3<f32>,
+  @location(2) uv : vec2<f32>,
+};
+
+@vertex
+fn vs(input : VertexInput) -> VertexOutput {
+  var output : VertexOutput;
+  let world = instanceUniform.model * vec4<f32>(input.position, 1.0);
+  output.position = scene.viewProj * world;
+  output.worldPos = world.xyz;
+  output.normal = normalize((instanceUniform.normal * vec4<f32>(input.normal, 0.0)).xyz);
+  output.uv = input.uv;
+  return output;
+}
+
+@fragment
+fn fs(input : VertexOutput) -> @location(0) vec4<f32> {
+  let sampledColor = textureSample(baseColorTexture, baseColorSampler, input.uv);
+  let baseColor = sampledColor * material.baseColorFactor;
+  return vec4<f32>(baseColor.rgb, baseColor.a);
+}

--- a/engine/render/materials/ubos.js
+++ b/engine/render/materials/ubos.js
@@ -1,15 +1,19 @@
 const FLOAT_SIZE = 4;
-const STANDARD_PBR_FLOATS = 8;
+const STANDARD_PBR_FLOATS = 12;
 const STANDARD_PBR_BUFFER_SIZE = STANDARD_PBR_FLOATS * FLOAT_SIZE;
 
 export const STANDARD_PBR_BINDINGS = {
   UNIFORM: 0,
   ALBEDO_TEXTURE: 1,
   ALBEDO_SAMPLER: 2,
-  NORMAL_TEXTURE: 3,
-  NORMAL_SAMPLER: 4,
-  ORM_TEXTURE: 5,
-  ORM_SAMPLER: 6
+  METALLIC_ROUGHNESS_TEXTURE: 3,
+  METALLIC_ROUGHNESS_SAMPLER: 4,
+  NORMAL_TEXTURE: 5,
+  NORMAL_SAMPLER: 6,
+  OCCLUSION_TEXTURE: 7,
+  OCCLUSION_SAMPLER: 8,
+  EMISSIVE_TEXTURE: 9,
+  EMISSIVE_SAMPLER: 10,
 };
 
 export function createStandardPBRLayout(device) {
@@ -19,10 +23,14 @@ export function createStandardPBRLayout(device) {
       { binding: STANDARD_PBR_BINDINGS.UNIFORM, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, buffer: { type: 'uniform' } },
       { binding: STANDARD_PBR_BINDINGS.ALBEDO_TEXTURE, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float' } },
       { binding: STANDARD_PBR_BINDINGS.ALBEDO_SAMPLER, visibility: GPUShaderStage.FRAGMENT, sampler: {} },
+      { binding: STANDARD_PBR_BINDINGS.METALLIC_ROUGHNESS_TEXTURE, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float' } },
+      { binding: STANDARD_PBR_BINDINGS.METALLIC_ROUGHNESS_SAMPLER, visibility: GPUShaderStage.FRAGMENT, sampler: {} },
       { binding: STANDARD_PBR_BINDINGS.NORMAL_TEXTURE, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float' } },
       { binding: STANDARD_PBR_BINDINGS.NORMAL_SAMPLER, visibility: GPUShaderStage.FRAGMENT, sampler: {} },
-      { binding: STANDARD_PBR_BINDINGS.ORM_TEXTURE, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float' } },
-      { binding: STANDARD_PBR_BINDINGS.ORM_SAMPLER, visibility: GPUShaderStage.FRAGMENT, sampler: {} }
+      { binding: STANDARD_PBR_BINDINGS.OCCLUSION_TEXTURE, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float' } },
+      { binding: STANDARD_PBR_BINDINGS.OCCLUSION_SAMPLER, visibility: GPUShaderStage.FRAGMENT, sampler: {} },
+      { binding: STANDARD_PBR_BINDINGS.EMISSIVE_TEXTURE, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float' } },
+      { binding: STANDARD_PBR_BINDINGS.EMISSIVE_SAMPLER, visibility: GPUShaderStage.FRAGMENT, sampler: {} },
     ]
   });
 }
@@ -44,34 +52,36 @@ export function updateStandardPBRUniform(device, uniform, material) {
 }
 
 export function describeStandardPBRBindings(material, uniform) {
-  const { albedo, normal, orm } = material.maps;
+  const { albedo, metallicRoughness, normal, occlusion, emissive } = material.maps;
   return {
     label: 'StandardPBRMaterial',
     entries: [
       { binding: STANDARD_PBR_BINDINGS.UNIFORM, resource: { buffer: uniform.buffer } },
       { binding: STANDARD_PBR_BINDINGS.ALBEDO_TEXTURE, resource: albedo.texture ?? null },
       { binding: STANDARD_PBR_BINDINGS.ALBEDO_SAMPLER, resource: albedo.sampler ?? null },
+      { binding: STANDARD_PBR_BINDINGS.METALLIC_ROUGHNESS_TEXTURE, resource: metallicRoughness.texture ?? null },
+      { binding: STANDARD_PBR_BINDINGS.METALLIC_ROUGHNESS_SAMPLER, resource: metallicRoughness.sampler ?? null },
       { binding: STANDARD_PBR_BINDINGS.NORMAL_TEXTURE, resource: normal.texture ?? null },
       { binding: STANDARD_PBR_BINDINGS.NORMAL_SAMPLER, resource: normal.sampler ?? null },
-      { binding: STANDARD_PBR_BINDINGS.ORM_TEXTURE, resource: orm.texture ?? null },
-      { binding: STANDARD_PBR_BINDINGS.ORM_SAMPLER, resource: orm.sampler ?? null }
+      { binding: STANDARD_PBR_BINDINGS.OCCLUSION_TEXTURE, resource: occlusion.texture ?? null },
+      { binding: STANDARD_PBR_BINDINGS.OCCLUSION_SAMPLER, resource: occlusion.sampler ?? null },
+      { binding: STANDARD_PBR_BINDINGS.EMISSIVE_TEXTURE, resource: emissive.texture ?? null },
+      { binding: STANDARD_PBR_BINDINGS.EMISSIVE_SAMPLER, resource: emissive.sampler ?? null },
     ]
   };
 }
 
-export function createStandardPBRBindGroup(device, layout, descriptor) {
+export function createStandardPBRBindGroup(device, layout, descriptor, fallbacks = {}) {
   if (!layout) {
     throw new Error('A bind group layout is required to create a Standard PBR bind group.');
   }
-  const ready = descriptor.entries.every(entry => entry.resource !== null);
-  if (!ready) {
-    console.debug('[Materials] Standard PBR bind group incomplete, awaiting texture or sampler resources.');
-    return null;
-  }
   const entries = descriptor.entries.map(entry => ({
     binding: entry.binding,
-    resource: entry.resource
+    resource: entry.resource ?? fallbacks[entry.binding]
   }));
+  if (entries.some(entry => entry.resource == null)) {
+    throw new Error('Missing resources for Standard PBR bind group.');
+  }
   return device.createBindGroup({
     label: descriptor.label,
     layout,

--- a/engine/render/mesh/drawList.js
+++ b/engine/render/mesh/drawList.js
@@ -1,0 +1,53 @@
+class MeshDrawList {
+  constructor() {
+    this.instances = new Set();
+    this._cache = [];
+    this._dirty = true;
+  }
+
+  register(instance) {
+    if (!instance) {
+      return;
+    }
+    this.instances.add(instance);
+    this._dirty = true;
+  }
+
+  unregister(instance) {
+    if (!instance) {
+      return;
+    }
+    if (this.instances.delete(instance)) {
+      this._dirty = true;
+    }
+  }
+
+  markDirty() {
+    this._dirty = true;
+  }
+
+  _refresh() {
+    if (!this._dirty) {
+      return;
+    }
+    this._cache = [];
+    for (const inst of this.instances) {
+      if (typeof inst.isRenderable === 'function') {
+        if (!inst.isRenderable()) {
+          continue;
+        }
+      }
+      this._cache.push(inst);
+    }
+    this._dirty = false;
+  }
+
+  getInstances() {
+    this._refresh();
+    return this._cache;
+  }
+}
+
+const drawList = new MeshDrawList();
+
+export default drawList;

--- a/engine/render/mesh/math.js
+++ b/engine/render/mesh/math.js
@@ -1,0 +1,374 @@
+const IDENTITY_MATRIX = new Float32Array([
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 1, 0,
+  0, 0, 0, 1,
+]);
+
+export function mat4Identity() {
+  return new Float32Array(IDENTITY_MATRIX);
+}
+
+export function mat4Multiply(a, b) {
+  const out = new Float32Array(16);
+  const a00 = a[0], a01 = a[1], a02 = a[2], a03 = a[3];
+  const a10 = a[4], a11 = a[5], a12 = a[6], a13 = a[7];
+  const a20 = a[8], a21 = a[9], a22 = a[10], a23 = a[11];
+  const a30 = a[12], a31 = a[13], a32 = a[14], a33 = a[15];
+
+  let b0 = b[0], b1 = b[1], b2 = b[2], b3 = b[3];
+  out[0] = a00 * b0 + a10 * b1 + a20 * b2 + a30 * b3;
+  out[1] = a01 * b0 + a11 * b1 + a21 * b2 + a31 * b3;
+  out[2] = a02 * b0 + a12 * b1 + a22 * b2 + a32 * b3;
+  out[3] = a03 * b0 + a13 * b1 + a23 * b2 + a33 * b3;
+
+  b0 = b[4]; b1 = b[5]; b2 = b[6]; b3 = b[7];
+  out[4] = a00 * b0 + a10 * b1 + a20 * b2 + a30 * b3;
+  out[5] = a01 * b0 + a11 * b1 + a21 * b2 + a31 * b3;
+  out[6] = a02 * b0 + a12 * b1 + a22 * b2 + a32 * b3;
+  out[7] = a03 * b0 + a13 * b1 + a23 * b2 + a33 * b3;
+
+  b0 = b[8]; b1 = b[9]; b2 = b[10]; b3 = b[11];
+  out[8] = a00 * b0 + a10 * b1 + a20 * b2 + a30 * b3;
+  out[9] = a01 * b0 + a11 * b1 + a21 * b2 + a31 * b3;
+  out[10] = a02 * b0 + a12 * b1 + a22 * b2 + a32 * b3;
+  out[11] = a03 * b0 + a13 * b1 + a23 * b2 + a33 * b3;
+
+  b0 = b[12]; b1 = b[13]; b2 = b[14]; b3 = b[15];
+  out[12] = a00 * b0 + a10 * b1 + a20 * b2 + a30 * b3;
+  out[13] = a01 * b0 + a11 * b1 + a21 * b2 + a31 * b3;
+  out[14] = a02 * b0 + a12 * b1 + a22 * b2 + a32 * b3;
+  out[15] = a03 * b0 + a13 * b1 + a23 * b2 + a33 * b3;
+  return out;
+}
+
+export function mat4Transpose(m) {
+  const out = new Float32Array(16);
+  out[0] = m[0];
+  out[1] = m[4];
+  out[2] = m[8];
+  out[3] = m[12];
+  out[4] = m[1];
+  out[5] = m[5];
+  out[6] = m[9];
+  out[7] = m[13];
+  out[8] = m[2];
+  out[9] = m[6];
+  out[10] = m[10];
+  out[11] = m[14];
+  out[12] = m[3];
+  out[13] = m[7];
+  out[14] = m[11];
+  out[15] = m[15];
+  return out;
+}
+
+export function mat4Invert(m) {
+  const inv = new Float32Array(16);
+
+  const m00 = m[0], m01 = m[1], m02 = m[2], m03 = m[3];
+  const m10 = m[4], m11 = m[5], m12 = m[6], m13 = m[7];
+  const m20 = m[8], m21 = m[9], m22 = m[10], m23 = m[11];
+  const m30 = m[12], m31 = m[13], m32 = m[14], m33 = m[15];
+
+  const b00 = m00 * m11 - m01 * m10;
+  const b01 = m00 * m12 - m02 * m10;
+  const b02 = m00 * m13 - m03 * m10;
+  const b03 = m01 * m12 - m02 * m11;
+  const b04 = m01 * m13 - m03 * m11;
+  const b05 = m02 * m13 - m03 * m12;
+  const b06 = m20 * m31 - m21 * m30;
+  const b07 = m20 * m32 - m22 * m30;
+  const b08 = m20 * m33 - m23 * m30;
+  const b09 = m21 * m32 - m22 * m31;
+  const b10 = m21 * m33 - m23 * m31;
+  const b11 = m22 * m33 - m23 * m32;
+
+  const det = b00 * b11 - b01 * b10 + b02 * b09 + b03 * b08 - b04 * b07 + b05 * b06;
+
+  if (!det) {
+    return mat4Identity();
+  }
+
+  const invDet = 1 / det;
+
+  inv[0] = (m11 * b11 - m12 * b10 + m13 * b09) * invDet;
+  inv[1] = (m02 * b10 - m01 * b11 - m03 * b09) * invDet;
+  inv[2] = (m31 * b05 - m32 * b04 + m33 * b03) * invDet;
+  inv[3] = (m22 * b04 - m21 * b05 - m23 * b03) * invDet;
+  inv[4] = (m12 * b08 - m10 * b11 - m13 * b07) * invDet;
+  inv[5] = (m00 * b11 - m02 * b08 + m03 * b07) * invDet;
+  inv[6] = (m32 * b02 - m30 * b05 - m33 * b01) * invDet;
+  inv[7] = (m20 * b05 - m22 * b02 + m23 * b01) * invDet;
+  inv[8] = (m10 * b10 - m11 * b08 + m13 * b06) * invDet;
+  inv[9] = (m01 * b08 - m00 * b10 - m03 * b06) * invDet;
+  inv[10] = (m30 * b04 - m31 * b02 + m33 * b00) * invDet;
+  inv[11] = (m21 * b02 - m20 * b04 - m23 * b00) * invDet;
+  inv[12] = (m11 * b07 - m10 * b09 - m12 * b06) * invDet;
+  inv[13] = (m00 * b09 - m01 * b07 + m02 * b06) * invDet;
+  inv[14] = (m31 * b01 - m30 * b03 - m32 * b00) * invDet;
+  inv[15] = (m20 * b03 - m21 * b01 + m22 * b00) * invDet;
+  return inv;
+}
+
+export function computeNormalMatrix(mat) {
+  const inverted = mat4Invert(mat);
+  const transposed = mat4Transpose(inverted);
+  // Zero out the last row/column to keep it purely 3x3
+  const out = new Float32Array(16);
+  out.set(transposed);
+  out[3] = 0;
+  out[7] = 0;
+  out[11] = 0;
+  out[12] = 0;
+  out[13] = 0;
+  out[14] = 0;
+  out[15] = 1;
+  return out;
+}
+
+export function degToRad(value) {
+  return (value * Math.PI) / 180;
+}
+
+export function radToDeg(value) {
+  return (value * 180) / Math.PI;
+}
+
+export function quaternionNormalize(q) {
+  const len = Math.hypot(q[0], q[1], q[2], q[3]);
+  if (len === 0) {
+    return new Float32Array([0, 0, 0, 1]);
+  }
+  return new Float32Array([q[0] / len, q[1] / len, q[2] / len, q[3] / len]);
+}
+
+export function quaternionFromEuler({ x = 0, y = 0, z = 0 } = {}) {
+  const rx = degToRad(x) * 0.5;
+  const ry = degToRad(y) * 0.5;
+  const rz = degToRad(z) * 0.5;
+
+  const sx = Math.sin(rx);
+  const cx = Math.cos(rx);
+  const sy = Math.sin(ry);
+  const cy = Math.cos(ry);
+  const sz = Math.sin(rz);
+  const cz = Math.cos(rz);
+
+  const qx = sx * cy * cz + cx * sy * sz;
+  const qy = cx * sy * cz - sx * cy * sz;
+  const qz = cx * cy * sz + sx * sy * cz;
+  const qw = cx * cy * cz - sx * sy * sz;
+  return quaternionNormalize(new Float32Array([qx, qy, qz, qw]));
+}
+
+export function quaternionToEuler(quat) {
+  const [x, y, z, w] = quat;
+
+  const sinr_cosp = 2 * (w * x + y * z);
+  const cosr_cosp = 1 - 2 * (x * x + y * y);
+  const roll = Math.atan2(sinr_cosp, cosr_cosp);
+
+  const sinp = 2 * (w * y - z * x);
+  let pitch;
+  if (Math.abs(sinp) >= 1) {
+    pitch = Math.sign(sinp) * Math.PI / 2;
+  } else {
+    pitch = Math.asin(sinp);
+  }
+
+  const siny_cosp = 2 * (w * z + x * y);
+  const cosy_cosp = 1 - 2 * (y * y + z * z);
+  const yaw = Math.atan2(siny_cosp, cosy_cosp);
+
+  return {
+    x: radToDeg(roll),
+    y: radToDeg(pitch),
+    z: radToDeg(yaw),
+  };
+}
+
+export function quaternionFromRotationMatrix(m) {
+  const trace = m[0] + m[5] + m[10];
+  let x;
+  let y;
+  let z;
+  let w;
+
+  if (trace > 0) {
+    const s = Math.sqrt(trace + 1.0) * 2;
+    w = 0.25 * s;
+    x = (m[6] - m[9]) / s;
+    y = (m[8] - m[2]) / s;
+    z = (m[1] - m[4]) / s;
+  } else if (m[0] > m[5] && m[0] > m[10]) {
+    const s = Math.sqrt(1.0 + m[0] - m[5] - m[10]) * 2;
+    w = (m[6] - m[9]) / s;
+    x = 0.25 * s;
+    y = (m[1] + m[4]) / s;
+    z = (m[8] + m[2]) / s;
+  } else if (m[5] > m[10]) {
+    const s = Math.sqrt(1.0 + m[5] - m[0] - m[10]) * 2;
+    w = (m[8] - m[2]) / s;
+    x = (m[1] + m[4]) / s;
+    y = 0.25 * s;
+    z = (m[6] + m[9]) / s;
+  } else {
+    const s = Math.sqrt(1.0 + m[10] - m[0] - m[5]) * 2;
+    w = (m[1] - m[4]) / s;
+    x = (m[8] + m[2]) / s;
+    y = (m[6] + m[9]) / s;
+    z = 0.25 * s;
+  }
+
+  return quaternionNormalize(new Float32Array([x, y, z, w]));
+}
+
+export function mat4FromRotationTranslationScale(quat, translation = [0, 0, 0], scale = [1, 1, 1]) {
+  const [x, y, z, w] = quat;
+  const x2 = x + x;
+  const y2 = y + y;
+  const z2 = z + z;
+
+  const xx = x * x2;
+  const xy = x * y2;
+  const xz = x * z2;
+  const yy = y * y2;
+  const yz = y * z2;
+  const zz = z * z2;
+  const wx = w * x2;
+  const wy = w * y2;
+  const wz = w * z2;
+
+  const sx = scale[0];
+  const sy = scale[1];
+  const sz = scale[2];
+
+  const out = new Float32Array(16);
+  out[0] = (1 - (yy + zz)) * sx;
+  out[1] = (xy + wz) * sx;
+  out[2] = (xz - wy) * sx;
+  out[3] = 0;
+
+  out[4] = (xy - wz) * sy;
+  out[5] = (1 - (xx + zz)) * sy;
+  out[6] = (yz + wx) * sy;
+  out[7] = 0;
+
+  out[8] = (xz + wy) * sz;
+  out[9] = (yz - wx) * sz;
+  out[10] = (1 - (xx + yy)) * sz;
+  out[11] = 0;
+
+  out[12] = translation[0];
+  out[13] = translation[1];
+  out[14] = translation[2];
+  out[15] = 1;
+  return out;
+}
+
+export function lookAt(eye, target, up) {
+  const zx = eye[0] - target[0];
+  const zy = eye[1] - target[1];
+  const zz = eye[2] - target[2];
+  let len = Math.hypot(zx, zy, zz);
+  const zxN = len > 0 ? zx / len : 0;
+  const zyN = len > 0 ? zy / len : 0;
+  const zzN = len > 0 ? zz / len : 0;
+
+  let xx = up[1] * zzN - up[2] * zyN;
+  let xy = up[2] * zxN - up[0] * zzN;
+  let xz = up[0] * zyN - up[1] * zxN;
+  len = Math.hypot(xx, xy, xz);
+  if (len === 0) {
+    xx = 0;
+    xy = 0;
+    xz = 0;
+  } else {
+    xx /= len;
+    xy /= len;
+    xz /= len;
+  }
+
+  const yx = zyN * xz - zzN * xy;
+  const yy = zzN * xx - zxN * xz;
+  const yz = zxN * xy - zyN * xx;
+
+  const out = new Float32Array(16);
+  out[0] = xx;
+  out[1] = yx;
+  out[2] = zxN;
+  out[3] = 0;
+  out[4] = xy;
+  out[5] = yy;
+  out[6] = zyN;
+  out[7] = 0;
+  out[8] = xz;
+  out[9] = yz;
+  out[10] = zzN;
+  out[11] = 0;
+  out[12] = -(xx * eye[0] + xy * eye[1] + xz * eye[2]);
+  out[13] = -(yx * eye[0] + yy * eye[1] + yz * eye[2]);
+  out[14] = -(zxN * eye[0] + zyN * eye[1] + zzN * eye[2]);
+  out[15] = 1;
+  return out;
+}
+
+export function perspective(fov, aspect, near, far) {
+  const f = 1.0 / Math.tan(fov / 2);
+  const nf = 1 / (near - far);
+  const out = new Float32Array(16);
+  out[0] = f / aspect;
+  out[1] = 0;
+  out[2] = 0;
+  out[3] = 0;
+  out[4] = 0;
+  out[5] = f;
+  out[6] = 0;
+  out[7] = 0;
+  out[8] = 0;
+  out[9] = 0;
+  out[10] = (far + near) * nf;
+  out[11] = -1;
+  out[12] = 0;
+  out[13] = 0;
+  out[14] = 2 * far * near * nf;
+  out[15] = 0;
+  return out;
+}
+
+export function decomposeTRS(matrix) {
+  const translation = [matrix[12], matrix[13], matrix[14]];
+
+  const sx = Math.hypot(matrix[0], matrix[1], matrix[2]);
+  const sy = Math.hypot(matrix[4], matrix[5], matrix[6]);
+  const sz = Math.hypot(matrix[8], matrix[9], matrix[10]);
+  const scale = [sx, sy, sz];
+
+  const invSx = sx !== 0 ? 1 / sx : 0;
+  const invSy = sy !== 0 ? 1 / sy : 0;
+  const invSz = sz !== 0 ? 1 / sz : 0;
+
+  const rot = [
+    matrix[0] * invSx, matrix[1] * invSx, matrix[2] * invSx,
+    matrix[4] * invSy, matrix[5] * invSy, matrix[6] * invSy,
+    matrix[8] * invSz, matrix[9] * invSz, matrix[10] * invSz,
+  ];
+
+  const quat = quaternionFromRotationMatrix([
+    rot[0], rot[1], rot[2], 0,
+    rot[3], rot[4], rot[5], 0,
+    rot[6], rot[7], rot[8], 0,
+    0, 0, 0, 1,
+  ]);
+
+  return { translation, rotation: quat, scale };
+}
+
+export function addVec3(a, b) {
+  return [a[0] + b[0], a[1] + b[1], a[2] + b[2]];
+}
+
+export function scaleVec3(v, s) {
+  return [v[0] * s, v[1] * s, v[2] * s];
+}

--- a/engine/render/mesh/mesh.js
+++ b/engine/render/mesh/mesh.js
@@ -1,0 +1,87 @@
+const FLOAT32_BYTES = 4;
+const VERTEX_FLOATS = 12;
+const VERTEX_STRIDE = VERTEX_FLOATS * FLOAT32_BYTES;
+
+function createGPUBuffer(device, data, usage) {
+  const buffer = device.createBuffer({
+    size: data.byteLength,
+    usage,
+    mappedAtCreation: true,
+  });
+  const arrayConstructor = data.constructor;
+  new arrayConstructor(buffer.getMappedRange()).set(data);
+  buffer.unmap();
+  return buffer;
+}
+
+function getIndexFormat(array) {
+  if (!array) {
+    return null;
+  }
+  if (array instanceof Uint32Array) {
+    return 'uint32';
+  }
+  if (array instanceof Uint16Array) {
+    return 'uint16';
+  }
+  if (array instanceof Uint8Array) {
+    return 'uint8';
+  }
+  throw new Error('Unsupported index array type');
+}
+
+export default class Mesh {
+  constructor(device, primitives = []) {
+    this.device = device;
+    this.primitives = primitives.map(primitive => this._createPrimitive(primitive));
+  }
+
+  _createPrimitive({ vertexData, indexData = null, materialId = null }) {
+    if (!(vertexData instanceof Float32Array)) {
+      throw new Error('vertexData must be a Float32Array');
+    }
+    const vertexBuffer = createGPUBuffer(
+      this.device,
+      vertexData,
+      GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+    );
+
+    let indexBuffer = null;
+    let indexFormat = null;
+    let indexCount = 0;
+    let vertexCount = vertexData.length / VERTEX_FLOATS;
+
+    if (indexData && indexData.length) {
+      indexBuffer = createGPUBuffer(
+        this.device,
+        indexData,
+        GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST,
+      );
+      indexFormat = getIndexFormat(indexData);
+      indexCount = indexData.length;
+    }
+
+    return {
+      vertexBuffer,
+      vertexCount,
+      indexBuffer,
+      indexFormat,
+      indexCount,
+      materialId,
+    };
+  }
+
+  destroy() {
+    for (const primitive of this.primitives) {
+      if (primitive.vertexBuffer) {
+        primitive.vertexBuffer.destroy();
+      }
+      if (primitive.indexBuffer) {
+        primitive.indexBuffer.destroy();
+      }
+    }
+    this.primitives.length = 0;
+  }
+}
+
+export { VERTEX_FLOATS, VERTEX_STRIDE };

--- a/engine/render/mesh/meshInstance.js
+++ b/engine/render/mesh/meshInstance.js
@@ -1,0 +1,267 @@
+import { Instance } from '../../core/index.js';
+import drawList from './drawList.js';
+import {
+  computeNormalMatrix,
+  mat4FromRotationTranslationScale,
+  mat4Identity,
+  mat4Multiply,
+  quaternionFromEuler,
+  quaternionNormalize,
+  quaternionToEuler,
+} from './math.js';
+
+function cloneVector3(value = {}) {
+  return {
+    x: Number.isFinite(value.x) ? value.x : 0,
+    y: Number.isFinite(value.y) ? value.y : 0,
+    z: Number.isFinite(value.z) ? value.z : 0,
+  };
+}
+
+function cloneScale(value = {}) {
+  const result = cloneVector3(value);
+  if (result.x === 0) result.x = 1;
+  if (result.y === 0) result.y = 1;
+  if (result.z === 0) result.z = 1;
+  return result;
+}
+
+function toArray(vec) {
+  return [vec.x, vec.y, vec.z];
+}
+
+class TransformNode extends Instance {
+  constructor(className = 'TransformNode') {
+    super(className);
+    this._position = cloneVector3({});
+    this._scale = cloneScale({ x: 1, y: 1, z: 1 });
+    this._rotationQuat = quaternionFromEuler();
+
+    super.setProperty('Position', cloneVector3(this._position));
+    super.setProperty('Scale', cloneVector3(this._scale));
+    super.setProperty('Rotation', cloneVector3(quaternionToEuler(this._rotationQuat)));
+
+    this._localMatrix = mat4Identity();
+    this._worldMatrix = mat4Identity();
+    this._normalMatrix = mat4Identity();
+    this._localDirty = true;
+    this._worldDirty = true;
+
+    this.AncestryChanged.Connect(() => {
+      this.markWorldDirty();
+    });
+  }
+
+  setProperty(name, value) {
+    if (name === 'Position') {
+      this._position = cloneVector3(value);
+      super.setProperty(name, cloneVector3(this._position));
+      this._localDirty = true;
+      this.markWorldDirty();
+      return;
+    }
+
+    if (name === 'Scale') {
+      this._scale = cloneScale(value);
+      super.setProperty(name, cloneVector3(this._scale));
+      this._localDirty = true;
+      this.markWorldDirty();
+      return;
+    }
+
+    if (name === 'Rotation') {
+      const vec = cloneVector3(value);
+      this._rotationQuat = quaternionFromEuler(vec);
+      super.setProperty(name, vec);
+      this._localDirty = true;
+      this.markWorldDirty();
+      return;
+    }
+
+    super.setProperty(name, value);
+  }
+
+  setRotationQuaternion(quat, updateProperty = true) {
+    this._rotationQuat = quaternionNormalize(quat);
+    if (updateProperty) {
+      super.setProperty('Rotation', cloneVector3(quaternionToEuler(this._rotationQuat)));
+    }
+    this._localDirty = true;
+    this.markWorldDirty();
+  }
+
+  getRotationQuaternion() {
+    return this._rotationQuat;
+  }
+
+  markWorldDirty() {
+    if (this._worldDirty && !this._localDirty) {
+      // Already marked; avoid redundant propagation.
+    }
+    this._worldDirty = true;
+    for (const child of this.Children) {
+      if (typeof child.markWorldDirty === 'function') {
+        child.markWorldDirty();
+      }
+    }
+  }
+
+  _updateLocalMatrix() {
+    if (!this._localDirty) {
+      return;
+    }
+    this._localMatrix = mat4FromRotationTranslationScale(
+      this._rotationQuat,
+      toArray(this._position),
+      toArray(this._scale),
+    );
+    this._localDirty = false;
+    this._worldDirty = true;
+  }
+
+  getLocalMatrix() {
+    this._updateLocalMatrix();
+    return this._localMatrix;
+  }
+
+  getWorldMatrix() {
+    this._updateLocalMatrix();
+    if (this._worldDirty) {
+      const parent = this.Parent;
+      if (parent && typeof parent.getWorldMatrix === 'function') {
+        this._worldMatrix = mat4Multiply(parent.getWorldMatrix(), this._localMatrix);
+      } else {
+        this._worldMatrix = new Float32Array(this._localMatrix);
+      }
+      this._normalMatrix = computeNormalMatrix(this._worldMatrix);
+      this._worldDirty = false;
+    }
+    return this._worldMatrix;
+  }
+
+  getNormalMatrix() {
+    this.getWorldMatrix();
+    return this._normalMatrix;
+  }
+
+  isRenderable() {
+    return this.Parent !== null;
+  }
+}
+
+class MeshInstance extends TransformNode {
+  constructor(mesh = null, { materials = null, className = 'MeshInstance' } = {}) {
+    super(className);
+    this.mesh = mesh;
+    this.materials = [];
+    this._uniformBuffer = null;
+    this._uniformArray = null;
+    this._bindGroup = null;
+    this._bindGroupLayout = null;
+    this._uniformDirty = true;
+
+    this.setMesh(mesh, materials);
+    drawList.register(this);
+  }
+
+  setMesh(mesh, materials = null) {
+    this.mesh = mesh;
+    this.materials = [];
+    if (mesh && Array.isArray(mesh.primitives)) {
+      this.materials = mesh.primitives.map((primitive, index) => {
+        if (Array.isArray(materials) && materials[index] != null) {
+          return materials[index];
+        }
+        return primitive.materialId ?? null;
+      });
+    }
+    this._uniformDirty = true;
+  }
+
+  setMaterial(index, materialId) {
+    if (!this.mesh) {
+      return;
+    }
+    while (this.materials.length < this.mesh.primitives.length) {
+      this.materials.push(null);
+    }
+    this.materials[index] = materialId;
+  }
+
+  getMaterialForPrimitive(index) {
+    if (!this.mesh || !this.mesh.primitives[index]) {
+      return null;
+    }
+    if (Array.isArray(this.materials) && this.materials[index] != null) {
+      return this.materials[index];
+    }
+    return this.mesh.primitives[index].materialId ?? null;
+  }
+
+  markWorldDirty() {
+    this._uniformDirty = true;
+    drawList.markDirty();
+    super.markWorldDirty();
+  }
+
+  isRenderable() {
+    return this.mesh !== null && super.isRenderable();
+  }
+
+  _ensureUniformBuffer(device) {
+    if (this._uniformBuffer) {
+      return;
+    }
+    const floatCount = 32; // 16 for model matrix, 16 for normal matrix
+    const byteLength = floatCount * 4;
+    this._uniformArray = new Float32Array(floatCount);
+    this._uniformBuffer = device.createBuffer({
+      size: byteLength,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+    this._uniformDirty = true;
+  }
+
+  _updateUniforms(device) {
+    if (!this._uniformDirty) {
+      return;
+    }
+    this._ensureUniformBuffer(device);
+    const world = this.getWorldMatrix();
+    const normal = this.getNormalMatrix();
+    this._uniformArray.set(world, 0);
+    this._uniformArray.set(normal, 16);
+    device.queue.writeBuffer(
+      this._uniformBuffer,
+      0,
+      this._uniformArray.buffer,
+      this._uniformArray.byteOffset,
+      this._uniformArray.byteLength,
+    );
+    this._uniformDirty = false;
+  }
+
+  getBindGroup(device, layout) {
+    if (!layout) {
+      return null;
+    }
+    this._ensureUniformBuffer(device);
+    if (!this._bindGroup || this._bindGroupLayout !== layout) {
+      this._bindGroupLayout = layout;
+      this._bindGroup = device.createBindGroup({
+        layout,
+        entries: [
+          {
+            binding: 0,
+            resource: { buffer: this._uniformBuffer },
+          },
+        ],
+      });
+    }
+    this._updateUniforms(device);
+    return this._bindGroup;
+  }
+}
+
+export { TransformNode, MeshInstance };
+export default MeshInstance;

--- a/engine/render/passes/meshPass.js
+++ b/engine/render/passes/meshPass.js
@@ -1,91 +1,250 @@
 import { recordDrawCall } from '../framegraph/stats.js';
+import drawList from '../mesh/drawList.js';
+import Materials from '../materials/registry.js';
+import { VERTEX_STRIDE } from '../mesh/mesh.js';
+import { lookAt, perspective, mat4Multiply, addVec3 } from '../mesh/math.js';
+import { GetService } from '../../core/index.js';
+
+const FLOAT_SIZE = 4;
+const SCENE_FLOATS = 36;
+const SCENE_BUFFER_SIZE = SCENE_FLOATS * FLOAT_SIZE;
 
 export default class MeshPass {
-  constructor(device, format, getView) {
+  constructor(device, format, getView, getSize) {
     this.device = device;
     this.format = format;
     this.getView = getView;
+    this.getSize = getSize;
+
     this.pipeline = null;
-    this.vertexBuffer = null;
+    this.sceneBuffer = null;
+    this.sceneArray = null;
+    this.sceneBindGroup = null;
+    this.sceneLayout = null;
+    this.instanceLayout = null;
+
+    this.depthTexture = null;
+    this.depthView = null;
+    this.depthFormat = 'depth24plus';
+    this.depthWidth = 0;
+    this.depthHeight = 0;
+
+    this.lighting = GetService('Lighting');
+  }
+
+  async _loadShaderModule() {
+    const url = new URL('../materials/pbrStandard.wgsl', import.meta.url);
+    const response = await fetch(url);
+    const code = await response.text();
+    return this.device.createShaderModule({ code });
   }
 
   async init() {
-    const shader = /* wgsl */`
-struct VertexOutput {
-  @builtin(position) position : vec4f,
-  @location(0) color : vec3f
-};
+    this.sceneArray = new Float32Array(SCENE_FLOATS);
+    this.sceneBuffer = this.device.createBuffer({
+      size: SCENE_BUFFER_SIZE,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
 
-@vertex
-fn vs(@location(0) position : vec3f) -> VertexOutput {
-  var out : VertexOutput;
-  out.position = vec4f(position, 1.0);
-  out.color = vec3f(1.0, 0.0, 0.0);
-  return out;
-}
+    this.sceneLayout = this.device.createBindGroupLayout({
+      label: 'MeshPassSceneLayout',
+      entries: [
+        { binding: 0, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT, buffer: { type: 'uniform' } },
+      ],
+    });
 
-@fragment
-fn fs(@location(0) color : vec3f) -> @location(0) vec4f {
-  return vec4f(color, 1.0);
-}`;
+    this.instanceLayout = this.device.createBindGroupLayout({
+      label: 'MeshPassInstanceLayout',
+      entries: [
+        { binding: 0, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform' } },
+      ],
+    });
 
-    const module = this.device.createShaderModule({ code: shader });
+    this.sceneBindGroup = this.device.createBindGroup({
+      label: 'MeshPassSceneBindGroup',
+      layout: this.sceneLayout,
+      entries: [
+        { binding: 0, resource: { buffer: this.sceneBuffer } },
+      ],
+    });
+
+    const materialLayout = Materials.getLayout('StandardPBR');
+    if (!materialLayout) {
+      throw new Error('StandardPBR material layout not available.');
+    }
+
+    const shaderModule = await this._loadShaderModule();
+    const pipelineLayout = this.device.createPipelineLayout({
+      bindGroupLayouts: [this.sceneLayout, materialLayout, this.instanceLayout],
+    });
+
     this.pipeline = this.device.createRenderPipeline({
-      layout: 'auto',
+      layout: pipelineLayout,
       vertex: {
-        module,
+        module: shaderModule,
         entryPoint: 'vs',
         buffers: [
           {
-            arrayStride: 3 * 4,
+            arrayStride: VERTEX_STRIDE,
             attributes: [
-              { shaderLocation: 0, offset: 0, format: 'float32x3' }
-            ]
-          }
-        ]
+              { shaderLocation: 0, offset: 0, format: 'float32x3' },
+              { shaderLocation: 1, offset: 12, format: 'float32x3' },
+              { shaderLocation: 2, offset: 24, format: 'float32x4' },
+              { shaderLocation: 3, offset: 40, format: 'float32x2' },
+            ],
+          },
+        ],
       },
       fragment: {
-        module,
+        module: shaderModule,
         entryPoint: 'fs',
-        targets: [{ format: this.format }]
+        targets: [
+          { format: this.format },
+        ],
       },
-      primitive: { topology: 'triangle-list' }
+      primitive: {
+        topology: 'triangle-list',
+        cullMode: 'back',
+      },
+      depthStencil: {
+        format: this.depthFormat,
+        depthWriteEnabled: true,
+        depthCompare: 'less',
+      },
     });
+  }
 
-    const vertices = new Float32Array([
-      -0.5, -0.5, 0.0,
-       0.5, -0.5, 0.0,
-       0.0,  0.5, 0.0
-    ]);
-
-    this.vertexBuffer = this.device.createBuffer({
-      size: vertices.byteLength,
-      usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
-      mappedAtCreation: true
+  _ensureDepthTexture(width, height) {
+    const w = Math.max(1, Math.floor(width));
+    const h = Math.max(1, Math.floor(height));
+    if (this.depthTexture && this.depthWidth === w && this.depthHeight === h) {
+      return;
+    }
+    if (this.depthTexture) {
+      this.depthTexture.destroy();
+    }
+    this.depthWidth = w;
+    this.depthHeight = h;
+    this.depthTexture = this.device.createTexture({
+      size: { width: w, height: h, depthOrArrayLayers: 1 },
+      format: this.depthFormat,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
     });
-    new Float32Array(this.vertexBuffer.getMappedRange()).set(vertices);
-    this.vertexBuffer.unmap();
+    this.depthView = this.depthTexture.createView();
+  }
+
+  _updateSceneUniform(width, height) {
+    const aspect = height > 0 ? width / height : 1;
+    const cameraState = this.lighting?.getCameraState ? this.lighting.getCameraState() : {
+      position: [0, 5, 15],
+      direction: [0, -0.3, -1],
+      up: [0, 1, 0],
+      near: 0.1,
+      far: 100,
+      fov: Math.PI / 3,
+      aspect: aspect,
+    };
+
+    if (this.lighting?.setCameraState) {
+      this.lighting.setCameraState({ aspect });
+    }
+
+    const target = addVec3(cameraState.position, cameraState.direction);
+    const view = lookAt(cameraState.position, target, cameraState.up);
+    const projection = perspective(cameraState.fov, aspect, cameraState.near, cameraState.far);
+    const viewProj = mat4Multiply(projection, view);
+
+    this.sceneArray.set(viewProj, 0);
+    this.sceneArray.set(view, 16);
+    this.sceneArray[32] = cameraState.position[0];
+    this.sceneArray[33] = cameraState.position[1];
+    this.sceneArray[34] = cameraState.position[2];
+    this.sceneArray[35] = 1.0;
+
+    this.device.queue.writeBuffer(
+      this.sceneBuffer,
+      0,
+      this.sceneArray.buffer,
+      this.sceneArray.byteOffset,
+      this.sceneArray.byteLength,
+    );
+
+    if (this.lighting?.update) {
+      this.lighting.update();
+    }
   }
 
   execute(encoder) {
     const view = this.getView ? this.getView() : null;
-    if (!view) {
+    if (!view || !this.pipeline) {
       return;
     }
+
+    const size = this.getSize ? this.getSize() : null;
+    const width = size?.width ?? this.depthWidth ?? 1;
+    const height = size?.height ?? this.depthHeight ?? 1;
+
+    this._ensureDepthTexture(width, height);
+    this._updateSceneUniform(width, height);
+
+    const instances = drawList.getInstances();
+    if (!instances.length) {
+      return;
+    }
+
     const pass = encoder.beginRenderPass({
       colorAttachments: [
         {
           view,
           loadOp: 'load',
-          storeOp: 'store'
-        }
-      ]
+          storeOp: 'store',
+        },
+      ],
+      depthStencilAttachment: {
+        view: this.depthView,
+        depthLoadOp: 'clear',
+        depthStoreOp: 'store',
+        depthClearValue: 1.0,
+      },
     });
+
     pass.setPipeline(this.pipeline);
-    pass.setVertexBuffer(0, this.vertexBuffer);
-    pass.draw(3, 1, 0, 0);
-    recordDrawCall(this.constructor.name);
+    pass.setBindGroup(0, this.sceneBindGroup);
+
+    for (const instance of instances) {
+      if (!instance.mesh) {
+        continue;
+      }
+      const instanceBindGroup = instance.getBindGroup(this.device, this.instanceLayout);
+      if (!instanceBindGroup) {
+        continue;
+      }
+
+      pass.setBindGroup(2, instanceBindGroup);
+
+      const mesh = instance.mesh;
+      for (let i = 0; i < mesh.primitives.length; i += 1) {
+        const primitive = mesh.primitives[i];
+        const materialId = instance.getMaterialForPrimitive(i);
+        const materialRecord = materialId != null ? Materials.get(materialId) : null;
+        const materialBindGroup = materialRecord?.binding?.bindGroup;
+        if (!materialBindGroup) {
+          continue;
+        }
+
+        pass.setBindGroup(1, materialBindGroup);
+        pass.setVertexBuffer(0, primitive.vertexBuffer);
+
+        if (primitive.indexBuffer && primitive.indexCount > 0) {
+          pass.setIndexBuffer(primitive.indexBuffer, primitive.indexFormat || 'uint32');
+          pass.drawIndexed(primitive.indexCount, 1, 0, 0, 0);
+        } else {
+          pass.draw(primitive.vertexCount, 1, 0, 0);
+        }
+        recordDrawCall(this.constructor.name);
+      }
+    }
+
     pass.end();
   }
 }
-

--- a/engine/render/post/hdr.js
+++ b/engine/render/post/hdr.js
@@ -33,4 +33,8 @@ export default class HDRTarget {
   getView() {
     return this.view;
   }
+
+  getSize() {
+    return { width: this.width, height: this.height };
+  }
 }

--- a/engine/scene/workspace.js
+++ b/engine/scene/workspace.js
@@ -1,0 +1,10 @@
+import { TransformNode } from '../render/mesh/meshInstance.js';
+
+const workspace = new TransformNode('Workspace');
+workspace.Name = 'Workspace';
+
+export function getWorkspace() {
+  return workspace;
+}
+
+export default workspace;

--- a/engine/services/Lighting.js
+++ b/engine/services/Lighting.js
@@ -42,6 +42,18 @@ export default class Lighting {
     };
   }
 
+  getCameraState() {
+    return {
+      position: [...this._camera.position],
+      direction: [...this._camera.direction],
+      up: [...this._camera.up],
+      near: this._camera.near,
+      far: this._camera.far,
+      fov: this._camera.fov,
+      aspect: this._camera.aspect,
+    };
+  }
+
   update() {
     if (!this.enabled) {
       return;

--- a/public/assets/sample/scene.gltf
+++ b/public/assets/sample/scene.gltf
@@ -1,0 +1,89 @@
+{
+  "asset": { "version": "2.0", "generator": "AxisForge Sample" },
+  "scene": 0,
+  "scenes": [
+    { "name": "SampleScene", "nodes": [0] }
+  ],
+  "nodes": [
+    { "name": "SampleTriangle", "mesh": 0 }
+  ],
+  "buffers": [
+    {
+      "uri": "data:application/octet-stream;base64,AAAAvwAAAL8AAAAAAAAAPwAAAL8AAAAAAAAAAAAAAD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAD8AAIA/AAABAAIA",
+      "byteLength": 102
+    }
+  ],
+  "bufferViews": [
+    { "buffer": 0, "byteOffset": 0, "byteLength": 36, "target": 34962 },
+    { "buffer": 0, "byteOffset": 36, "byteLength": 36, "target": 34962 },
+    { "buffer": 0, "byteOffset": 72, "byteLength": 24, "target": 34962 },
+    { "buffer": 0, "byteOffset": 96, "byteLength": 6, "target": 34963 }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5126,
+      "count": 3,
+      "type": "VEC3",
+      "min": [-0.5, -0.5, 0.0],
+      "max": [0.5, 0.5, 0.0]
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5126,
+      "count": 3,
+      "type": "VEC3"
+    },
+    {
+      "bufferView": 2,
+      "componentType": 5126,
+      "count": 3,
+      "type": "VEC2"
+    },
+    {
+      "bufferView": 3,
+      "componentType": 5123,
+      "count": 3,
+      "type": "SCALAR"
+    }
+  ],
+  "materials": [
+    {
+      "name": "TriangleMaterial",
+      "pbrMetallicRoughness": {
+        "baseColorTexture": { "index": 0 },
+        "baseColorFactor": [1.0, 1.0, 1.0, 1.0],
+        "metallicFactor": 0.0,
+        "roughnessFactor": 0.5
+      },
+      "emissiveFactor": [0.0, 0.0, 0.0]
+    }
+  ],
+  "images": [
+    {
+      "uri": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
+    }
+  ],
+  "samplers": [
+    { "magFilter": 9729, "minFilter": 9987, "wrapS": 10497, "wrapT": 10497 }
+  ],
+  "textures": [
+    { "sampler": 0, "source": 0 }
+  ],
+  "meshes": [
+    {
+      "name": "TriangleMesh",
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 0,
+            "NORMAL": 1,
+            "TEXCOORD_0": 2
+          },
+          "indices": 3,
+          "material": 0
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- inline the sample triangle buffer and texture as data URIs in the glTF JSON so no binary files are required
- extend the glTF loader to decode data URIs for buffers and textures without relying on fetch

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3626e728c832c8039c23b9894d62f