### PR TITLE
Add render list frustum culling and stats

### DIFF
--- a/editor/panes/profiler.js
+++ b/editor/panes/profiler.js
@@ -65,6 +65,18 @@ export default class ProfilerPane {
     this.totalDrawValue = totalDrawRow.valueEl;
     this.root.appendChild(totalDrawRow.row);
 
+    const meshTotalRow = createStatRow('Mesh Instances');
+    this.meshTotalValue = meshTotalRow.valueEl;
+    this.root.appendChild(meshTotalRow.row);
+
+    const meshVisibleRow = createStatRow('Visible Meshes');
+    this.meshVisibleValue = meshVisibleRow.valueEl;
+    this.root.appendChild(meshVisibleRow.row);
+
+    const meshCulledRow = createStatRow('Culled Meshes');
+    this.meshCulledValue = meshCulledRow.valueEl;
+    this.root.appendChild(meshCulledRow.row);
+
     const divider = document.createElement('div');
     divider.style.height = '1px';
     divider.style.background = 'rgba(255, 255, 255, 0.1)';
@@ -113,11 +125,18 @@ export default class ProfilerPane {
     const fps = Number.isFinite(stats.fps) ? stats.fps : 0;
     const frameTime = Number.isFinite(stats.cpuFrameTime) ? stats.cpuFrameTime : 0;
     const totalDrawCalls = typeof stats.totalDrawCalls === 'number' ? stats.totalDrawCalls : 0;
+    const meshStats = stats.meshInstances || {};
+    const meshTotal = typeof meshStats.total === 'number' ? meshStats.total : 0;
+    const meshVisible = typeof meshStats.visible === 'number' ? meshStats.visible : 0;
+    const meshCulled = typeof meshStats.culled === 'number' ? meshStats.culled : 0;
 
     this.fpsValue.textContent = fps.toFixed(1);
     this.frameTimeValue.textContent = frameTime.toFixed(2);
     this.gpuValue.textContent = stats.gpuAdapterName || 'Detecting…';
     this.totalDrawValue.textContent = totalDrawCalls.toString();
+    this.meshTotalValue.textContent = meshTotal.toString();
+    this.meshVisibleValue.textContent = meshVisible.toString();
+    this.meshCulledValue.textContent = meshCulled.toString();
 
     this._syncPassRows(stats.passes || {});
   }

--- a/engine/render/framegraph/stats.js
+++ b/engine/render/framegraph/stats.js
@@ -12,6 +12,11 @@ const frameStats = {
   totalDrawCalls: 0,
   passes: {},
   renderCpuTime: 0,
+  meshInstances: {
+    total: 0,
+    visible: 0,
+    culled: 0,
+  },
 };
 
 let frameStartTime = 0;
@@ -20,6 +25,9 @@ export function beginFrame() {
   frameStartTime = now();
   frameStats.totalDrawCalls = 0;
   frameStats.passes = {};
+  frameStats.meshInstances.total = 0;
+  frameStats.meshInstances.visible = 0;
+  frameStats.meshInstances.culled = 0;
 }
 
 export function endFrame() {
@@ -38,6 +46,12 @@ export function recordDrawCall(name, count = 1) {
   markPass(passName);
   frameStats.passes[passName].drawCalls += count;
   frameStats.totalDrawCalls += count;
+}
+
+export function setMeshInstanceStats({ total = 0, visible = 0, culled = 0 } = {}) {
+  frameStats.meshInstances.total = total;
+  frameStats.meshInstances.visible = visible;
+  frameStats.meshInstances.culled = culled;
 }
 
 export function updateFrameMetrics(deltaSeconds) {

--- a/engine/render/passes/meshPass.js
+++ b/engine/render/passes/meshPass.js
@@ -1,10 +1,10 @@
 import { recordDrawCall } from '../framegraph/stats.js';
-import drawList from '../mesh/drawList.js';
 import Materials from '../materials/registry.js';
 import { VERTEX_STRIDE } from '../mesh/mesh.js';
 import { lookAt, perspective, mat4Multiply, addVec3 } from '../mesh/math.js';
 import { GetService } from '../../core/index.js';
 import { getActiveCamera, getGridFade } from '../camera/manager.js';
+import renderList from '../scene/renderList.js';
 
 const FLOAT_SIZE = 4;
 const MAX_CASCADES = 4;
@@ -579,9 +579,9 @@ export default class MeshPass {
     this._ensureDepthTexture(width, height);
     const cameraInfo = this._updateSceneUniform(width, height);
 
-    const instances = drawList.getInstances();
+    const visibleInstances = renderList.update(cameraInfo);
     const shouldDrawGrid = this.gridPipeline && getGridFade() > 0.001;
-    if (!instances.length && !shouldDrawGrid) {
+    if (!visibleInstances.length && !shouldDrawGrid) {
       return;
     }
 
@@ -605,11 +605,11 @@ export default class MeshPass {
       this._drawGrid(pass, cameraInfo);
     }
 
-    if (instances.length) {
+    if (visibleInstances.length) {
       pass.setPipeline(this.pipeline);
       pass.setBindGroup(0, this.sceneBindGroup);
 
-      for (const instance of instances) {
+      for (const instance of visibleInstances) {
         if (!instance.mesh) {
           continue;
         }

--- a/engine/render/scene/culling.js
+++ b/engine/render/scene/culling.js
@@ -1,0 +1,155 @@
+const ZERO_BOUNDS = {
+  min: [0, 0, 0],
+  max: [0, 0, 0],
+};
+
+function ensureTargetBounds(target) {
+  if (target && target.min && target.max) {
+    return target;
+  }
+  return {
+    min: [0, 0, 0],
+    max: [0, 0, 0],
+  };
+}
+
+export function transformAABB(matrix, bounds, target = null) {
+  if (!matrix || !bounds || !bounds.min || !bounds.max) {
+    return target ?? null;
+  }
+
+  const out = ensureTargetBounds(target);
+
+  const min = bounds.min;
+  const max = bounds.max;
+
+  const centerX = (min[0] + max[0]) * 0.5;
+  const centerY = (min[1] + max[1]) * 0.5;
+  const centerZ = (min[2] + max[2]) * 0.5;
+
+  const extentX = (max[0] - min[0]) * 0.5;
+  const extentY = (max[1] - min[1]) * 0.5;
+  const extentZ = (max[2] - min[2]) * 0.5;
+
+  const worldCenterX =
+    matrix[0] * centerX +
+    matrix[4] * centerY +
+    matrix[8] * centerZ +
+    matrix[12];
+  const worldCenterY =
+    matrix[1] * centerX +
+    matrix[5] * centerY +
+    matrix[9] * centerZ +
+    matrix[13];
+  const worldCenterZ =
+    matrix[2] * centerX +
+    matrix[6] * centerY +
+    matrix[10] * centerZ +
+    matrix[14];
+
+  const worldExtentX =
+    Math.abs(matrix[0]) * extentX +
+    Math.abs(matrix[4]) * extentY +
+    Math.abs(matrix[8]) * extentZ;
+  const worldExtentY =
+    Math.abs(matrix[1]) * extentX +
+    Math.abs(matrix[5]) * extentY +
+    Math.abs(matrix[9]) * extentZ;
+  const worldExtentZ =
+    Math.abs(matrix[2]) * extentX +
+    Math.abs(matrix[6]) * extentY +
+    Math.abs(matrix[10]) * extentZ;
+
+  out.min[0] = worldCenterX - worldExtentX;
+  out.min[1] = worldCenterY - worldExtentY;
+  out.min[2] = worldCenterZ - worldExtentZ;
+
+  out.max[0] = worldCenterX + worldExtentX;
+  out.max[1] = worldCenterY + worldExtentY;
+  out.max[2] = worldCenterZ + worldExtentZ;
+
+  return out;
+}
+
+function normalizePlane(a, b, c, d) {
+  const length = Math.hypot(a, b, c);
+  if (length === 0) {
+    return { normal: [0, 0, 0], constant: 0 };
+  }
+  const inv = 1 / length;
+  return {
+    normal: [a * inv, b * inv, c * inv],
+    constant: d * inv,
+  };
+}
+
+export function extractFrustumPlanes(matrix) {
+  if (!matrix || matrix.length !== 16) {
+    return null;
+  }
+
+  const m00 = matrix[0];
+  const m01 = matrix[4];
+  const m02 = matrix[8];
+  const m03 = matrix[12];
+  const m10 = matrix[1];
+  const m11 = matrix[5];
+  const m12 = matrix[9];
+  const m13 = matrix[13];
+  const m20 = matrix[2];
+  const m21 = matrix[6];
+  const m22 = matrix[10];
+  const m23 = matrix[14];
+  const m30 = matrix[3];
+  const m31 = matrix[7];
+  const m32 = matrix[11];
+  const m33 = matrix[15];
+
+  const planes = [
+    normalizePlane(m30 + m00, m31 + m01, m32 + m02, m33 + m03), // Left
+    normalizePlane(m30 - m00, m31 - m01, m32 - m02, m33 - m03), // Right
+    normalizePlane(m30 + m10, m31 + m11, m32 + m12, m33 + m13), // Bottom
+    normalizePlane(m30 - m10, m31 - m11, m32 - m12, m33 - m13), // Top
+    normalizePlane(m30 + m20, m31 + m21, m32 + m22, m33 + m23), // Near
+    normalizePlane(m30 - m20, m31 - m21, m32 - m22, m33 - m23), // Far
+  ];
+
+  return planes;
+}
+
+export function isAABBVisible(bounds, planes) {
+  if (!bounds || !bounds.min || !bounds.max) {
+    return true;
+  }
+  if (!planes || planes.length === 0) {
+    return true;
+  }
+
+  const { min, max } = bounds;
+
+  for (const plane of planes) {
+    const normal = plane?.normal ?? ZERO_BOUNDS.min;
+    const constant = plane?.constant ?? 0;
+
+    const px = normal[0] >= 0 ? max[0] : min[0];
+    const py = normal[1] >= 0 ? max[1] : min[1];
+    const pz = normal[2] >= 0 ? max[2] : min[2];
+
+    const distance = normal[0] * px + normal[1] * py + normal[2] * pz + constant;
+    if (distance < 0) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export function countVisible(boundsList, planes) {
+  let visible = 0;
+  for (const bounds of boundsList || []) {
+    if (isAABBVisible(bounds, planes)) {
+      visible += 1;
+    }
+  }
+  return visible;
+}

--- a/engine/render/scene/renderList.js
+++ b/engine/render/scene/renderList.js
@@ -1,0 +1,83 @@
+import drawList from '../mesh/drawList.js';
+import { extractFrustumPlanes, isAABBVisible } from './culling.js';
+import { setMeshInstanceStats } from '../framegraph/stats.js';
+
+class RenderList {
+  constructor() {
+    this._visible = [];
+    this._frustumPlanes = null;
+    this._stats = {
+      total: 0,
+      visible: 0,
+      culled: 0,
+    };
+  }
+
+  update(cameraInfo = null) {
+    const instances = drawList.getInstances();
+    const total = instances.length;
+
+    this._visible.length = 0;
+    this._stats.total = total;
+    this._stats.culled = 0;
+    this._stats.visible = 0;
+
+    if (total === 0) {
+      setMeshInstanceStats({ total: 0, visible: 0, culled: 0 });
+      this._frustumPlanes = null;
+      return this._visible;
+    }
+
+    const viewProjection = cameraInfo?.viewProjection;
+    this._frustumPlanes = viewProjection ? extractFrustumPlanes(viewProjection) : null;
+
+    if (!this._frustumPlanes) {
+      this._visible.push(...instances);
+      this._stats.visible = total;
+      setMeshInstanceStats({ total, visible: total, culled: 0 });
+      return this._visible;
+    }
+
+    for (const instance of instances) {
+      if (!instance) {
+        continue;
+      }
+      const bounds = typeof instance.getWorldBounds === 'function'
+        ? instance.getWorldBounds()
+        : null;
+      if (!bounds || isAABBVisible(bounds, this._frustumPlanes)) {
+        this._visible.push(instance);
+      }
+    }
+
+    const visibleCount = this._visible.length;
+    const culledCount = Math.max(0, total - visibleCount);
+
+    this._stats.visible = visibleCount;
+    this._stats.culled = culledCount;
+
+    setMeshInstanceStats({
+      total,
+      visible: visibleCount,
+      culled: culledCount,
+    });
+
+    return this._visible;
+  }
+
+  getVisibleInstances() {
+    return this._visible;
+  }
+
+  getStats() {
+    return { ...this._stats };
+  }
+
+  getFrustumPlanes() {
+    return this._frustumPlanes;
+  }
+}
+
+const renderList = new RenderList();
+
+export default renderList;


### PR DESCRIPTION
## Summary
- compute mesh-local bounds once and expose world bounds on mesh instances
- add scene render list with frustum culling and update frame stats for visible meshes
- surface mesh instance totals and culling counts in the profiler overlay

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4427909ec832caee8c9a584952cba