### PR TITLE
Add scene serialization for meshes and materials

### DIFF
--- a/editor/services/assets.js
+++ b/editor/services/assets.js
@@ -192,6 +192,14 @@ export class AssetRegistry {
   list() {
     return this.assets.map(cloneAsset);
   }
+
+  getByGuid(guid) {
+    if (!guid) {
+      return null;
+    }
+    const asset = this.assets.find(entry => entry.guid === guid);
+    return asset ? cloneAsset(asset) : null;
+  }
 }
 
 export class AssetService {
@@ -234,6 +242,11 @@ export class AssetService {
 
   getURI(asset) {
     return `assets://${asset.logicalPath}`;
+  }
+
+  async get(guid) {
+    await this.ready;
+    return this.registry.getByGuid(guid);
   }
 }
 

--- a/editor/services/materialRegistry.js
+++ b/editor/services/materialRegistry.js
@@ -291,6 +291,12 @@ class EditorMaterialRegistry {
       logicalPath: asset.logicalPath,
     });
 
+    Materials.rememberTextureAsset(materialId, slot.key, {
+      guid: asset.guid,
+      name: asset.name,
+      logicalPath: asset.logicalPath,
+    });
+
     this.updateMaterial(materialId, params);
   }
 
@@ -312,6 +318,7 @@ class EditorMaterialRegistry {
       store.delete(slot.key);
     }
     this._rememberAssignment(materialId, slot.key, null);
+    Materials.rememberTextureAsset(materialId, slot.key, null);
     this.updateMaterial(materialId, {
       [slot.paramTexture]: null,
       [slot.paramSampler]: null,

--- a/engine/render/materials/registry.js
+++ b/engine/render/materials/registry.js
@@ -17,6 +17,7 @@ class MaterialRegistry {
     this.nextId = 1;
     this.defaults = new Map();
     this._defaultTextures = [];
+    this._metadata = new Map();
   }
 
   init(device) {
@@ -25,6 +26,7 @@ class MaterialRegistry {
       this.materials.clear();
       this.nextId = 1;
       this._disposeDefaults();
+      this._metadata.clear();
     }
     if (!this.device || this.device !== device) {
       this.device = device;
@@ -125,6 +127,10 @@ class MaterialRegistry {
     const binding = this._buildStandardBinding(material, uniform);
     const id = this.nextId++;
     const record = { id, type: material.type, material, uniform, binding };
+    this._metadata.set(id, {
+      name: params?.name || `Material ${id}`,
+      textures: {},
+    });
     this.materials.set(id, record);
     this._logRecord('Created', record);
     return id;
@@ -147,6 +153,75 @@ class MaterialRegistry {
 
   getLayout(type) {
     return this.layouts.get(type) || null;
+  }
+
+  _ensureMetadata(id) {
+    if (!this._metadata.has(id)) {
+      this._metadata.set(id, { name: `Material ${id}`, textures: {} });
+    }
+    const meta = this._metadata.get(id);
+    if (!meta.textures) {
+      meta.textures = {};
+    }
+    return meta;
+  }
+
+  setName(id, name) {
+    const meta = this._ensureMetadata(id);
+    if (name && typeof name === 'string') {
+      meta.name = name;
+    } else {
+      meta.name = `Material ${id}`;
+    }
+  }
+
+  getMetadata(id) {
+    const meta = this._metadata.get(id);
+    if (!meta) {
+      return { name: `Material ${id}`, textures: {} };
+    }
+    const textures = {};
+    for (const [slot, info] of Object.entries(meta.textures || {})) {
+      if (info && typeof info === 'object') {
+        textures[slot] = { ...info };
+      }
+    }
+    return {
+      name: meta.name || `Material ${id}`,
+      textures,
+    };
+  }
+
+  rememberTextureAsset(id, slotKey, assetInfo) {
+    const meta = this._ensureMetadata(id);
+    if (!slotKey) {
+      return;
+    }
+    if (assetInfo) {
+      meta.textures[slotKey] = {
+        guid: assetInfo.guid || null,
+        name: assetInfo.name || null,
+        logicalPath: assetInfo.logicalPath || null,
+      };
+    } else {
+      delete meta.textures[slotKey];
+    }
+  }
+
+  setMetadata(id, metadata = {}) {
+    const meta = this._ensureMetadata(id);
+    meta.name = typeof metadata.name === 'string' && metadata.name.length > 0 ? metadata.name : `Material ${id}`;
+    meta.textures = {};
+    const textures = metadata.textures || {};
+    for (const [slot, info] of Object.entries(textures)) {
+      if (info && typeof info === 'object' && info.guid) {
+        meta.textures[slot] = {
+          guid: info.guid,
+          name: info.name || null,
+          logicalPath: info.logicalPath || null,
+        };
+      }
+    }
   }
 }
 

--- a/engine/scene/deserialize.js
+++ b/engine/scene/deserialize.js
@@ -1,9 +1,159 @@
 import { Instance, GetService } from '../core/index.js';
+import Mesh from '../render/mesh/mesh.js';
+import Materials from '../render/materials/registry.js';
+import { tryGetDevice } from '../render/gpu/device.js';
+
+const INDEX_ARRAY_TYPES = {
+  Uint32Array,
+  Uint16Array,
+  Uint8Array,
+};
+
+function normalizeSceneData(data) {
+  if (data && typeof data === 'object' && data.version != null && data.root) {
+    return {
+      version: data.version,
+      root: data.root,
+      meshes: Array.isArray(data.meshes) ? data.meshes : [],
+      materials: Array.isArray(data.materials) ? data.materials : [],
+    };
+  }
+  return {
+    version: 0,
+    root: data,
+    meshes: [],
+    materials: [],
+  };
+}
+
+function createIndexArray(serialized) {
+  if (!serialized || !serialized.data) {
+    return null;
+  }
+  const ctor = INDEX_ARRAY_TYPES[serialized.type] || Uint32Array;
+  return new ctor(serialized.data);
+}
+
+function restoreMeshAssets(meshDefs, device) {
+  const meshes = new Map();
+  if (!meshDefs || meshDefs.length === 0) {
+    return meshes;
+  }
+
+  if (!device) {
+    throw new Error('GPU device is required to deserialize mesh assets.');
+  }
+
+  for (const meshDef of meshDefs) {
+    if (!meshDef) {
+      continue;
+    }
+    const primitives = (meshDef.primitives || []).map(primitive => ({
+      vertexData: new Float32Array(primitive.vertexData || []),
+      indexData: createIndexArray(primitive.indexData),
+      materialId: primitive.materialId ?? null,
+    }));
+    const mesh = new Mesh(device, primitives);
+    if (meshDef.guid) {
+      mesh.assetGuid = meshDef.guid;
+    }
+    const key = mesh.assetGuid || meshDef.guid || `${meshes.size}`;
+    meshes.set(key, mesh);
+  }
+
+  return meshes;
+}
+
+function applyMaterialMetadata(targetId, materialDef) {
+  const metadata = {
+    name: materialDef?.name,
+    textures: materialDef?.textures || {},
+  };
+  if (typeof Materials.setMetadata === 'function') {
+    Materials.setMetadata(targetId, metadata);
+  } else if (typeof Materials.setName === 'function') {
+    Materials.setName(targetId, metadata.name);
+  }
+}
+
+function restoreMaterials(materialDefs = [], options = {}) {
+  const idMap = new Map();
+  const assignments = [];
+
+  for (const materialDef of materialDefs) {
+    if (!materialDef || materialDef.id == null) {
+      continue;
+    }
+
+    const params = materialDef.parameters || {};
+    const existing = Materials.get(materialDef.id);
+    let targetId = materialDef.id;
+
+    if (existing) {
+      Materials.update(targetId, params);
+    } else {
+      targetId = Materials.createStandard(params);
+    }
+
+    applyMaterialMetadata(targetId, materialDef);
+
+    idMap.set(materialDef.id, targetId);
+    assignments.push({ targetId, textures: materialDef.textures || {} });
+  }
+
+  assignMaterialTextures(assignments, options);
+  return idMap;
+}
+
+function assignMaterialTextures(assignments, options = {}) {
+  if (!assignments.length) {
+    return;
+  }
+
+  let resolveAsset = null;
+  if (typeof options.resolveAsset === 'function') {
+    resolveAsset = options.resolveAsset;
+  } else if (options.assetService && typeof options.assetService.get === 'function') {
+    resolveAsset = guid => options.assetService.get(guid);
+  }
+
+  let assignTexture = null;
+  if (typeof options.assignTextureFromAsset === 'function') {
+    assignTexture = options.assignTextureFromAsset;
+  } else if (options.materialRegistry && typeof options.materialRegistry.assignTextureFromAsset === 'function') {
+    assignTexture = options.materialRegistry.assignTextureFromAsset.bind(options.materialRegistry);
+  }
+
+  if (!resolveAsset || !assignTexture) {
+    return;
+  }
+
+  for (const entry of assignments) {
+    const { targetId, textures } = entry;
+    for (const [slotKey, assetInfo] of Object.entries(textures || {})) {
+      if (!assetInfo?.guid) {
+        continue;
+      }
+      Promise.resolve(resolveAsset(assetInfo.guid, slotKey, targetId))
+        .then(asset => {
+          if (!asset) {
+            return null;
+          }
+          Materials.rememberTextureAsset(targetId, slotKey, assetInfo);
+          return assignTexture(targetId, slotKey, asset);
+        })
+        .catch(err => {
+          console.warn('[Scene] Failed to restore texture for material', targetId, slotKey, err);
+        });
+    }
+  }
+}
 
 // Deserialize a JSON string produced by serialize() back into an Instance
 // hierarchy. Service instances are reused if they already exist.
 export function deserialize(json, options = {}) {
-  const data = typeof json === 'string' ? JSON.parse(json) : json;
+  const raw = typeof json === 'string' ? JSON.parse(json) : json;
+  const data = normalizeSceneData(raw);
   const { getService, services } = options || {};
 
   const resolveService =
@@ -12,6 +162,21 @@ export function deserialize(json, options = {}) {
       : services instanceof Map
       ? name => services.get(name)
       : name => GetService(name);
+
+  const device =
+    options.device ||
+    (typeof options.getDevice === 'function' ? options.getDevice() : null) ||
+    tryGetDevice();
+
+  const meshAssets = restoreMeshAssets(data.meshes, device);
+  const materialIdMap = restoreMaterials(data.materials, options);
+
+  const remapMaterialId = id => {
+    if (id == null) {
+      return null;
+    }
+    return materialIdMap.has(id) ? materialIdMap.get(id) : id;
+  };
 
   function build(node) {
     // Reuse existing service instances when available
@@ -35,10 +200,38 @@ export function deserialize(json, options = {}) {
       const childInst = build(child);
       childInst.Parent = inst;
     }
+
+    if (node.meshInstance && typeof inst.setMesh === 'function') {
+      const meshGuid = node.meshInstance.mesh;
+      const mesh = meshGuid ? meshAssets.get(meshGuid) || null : null;
+      if (mesh) {
+        inst.setMesh(mesh);
+      }
+
+      if (Array.isArray(node.meshInstance.materials) && typeof inst.setMaterial === 'function') {
+        node.meshInstance.materials.forEach((materialId, index) => {
+          const mapped = remapMaterialId(materialId);
+          if (mapped != null) {
+            inst.setMaterial(index, mapped);
+          }
+        });
+      }
+
+      const transform = node.meshInstance.transform || {};
+      if (transform.position) {
+        inst.setProperty('Position', transform.position);
+      }
+      if (transform.rotation) {
+        inst.setProperty('Rotation', transform.rotation);
+      }
+      if (transform.scale) {
+        inst.setProperty('Scale', transform.scale);
+      }
+    }
     return inst;
   }
 
-  return build(data);
+  return build(data.root);
 }
 
 export default deserialize;

--- a/engine/scene/serialize.js
+++ b/engine/scene/serialize.js
@@ -1,10 +1,115 @@
 import guid from './guid.js';
 import { Signal } from '../core/signal.js';
+import Materials from '../render/materials/registry.js';
+
+const SCENE_SERIALIZATION_VERSION = 1;
+
+function cloneVector(value) {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  return {
+    x: Number(value.x) || 0,
+    y: Number(value.y) || 0,
+    z: Number(value.z) || 0,
+  };
+}
+
+function cloneBounds(bounds) {
+  if (!bounds) {
+    return null;
+  }
+  return {
+    min: Array.isArray(bounds.min) ? [...bounds.min] : null,
+    max: Array.isArray(bounds.max) ? [...bounds.max] : null,
+  };
+}
+
+function isMeshInstance(inst) {
+  return Boolean(inst && typeof inst === 'object' && typeof inst.getMaterialForPrimitive === 'function' && inst.mesh);
+}
+
+function serializeMeshAsset(mesh, meshAssets, collectMaterial) {
+  if (!mesh) {
+    return null;
+  }
+
+  if (!mesh.assetGuid) {
+    mesh.assetGuid = guid();
+  }
+
+  const assetGuid = mesh.assetGuid;
+  if (meshAssets.has(assetGuid)) {
+    return assetGuid;
+  }
+
+  const cpuPrimitives = typeof mesh.getCPUPrimitives === 'function' ? mesh.getCPUPrimitives() : [];
+  const primitives = cpuPrimitives.map(primitive => {
+    if (primitive.materialId != null) {
+      collectMaterial(primitive.materialId);
+    }
+
+    let indexData = null;
+    if (primitive.indexData && primitive.indexData.length) {
+      indexData = {
+        type: primitive.indexData.constructor?.name || null,
+        data: Array.from(primitive.indexData),
+      };
+    }
+
+    return {
+      vertexData: primitive.vertexData ? Array.from(primitive.vertexData) : [],
+      indexData,
+      materialId: primitive.materialId ?? null,
+    };
+  });
+
+  meshAssets.set(assetGuid, {
+    guid: assetGuid,
+    primitives,
+    bounds: cloneBounds(mesh.bounds),
+  });
+
+  return assetGuid;
+}
+
+function collectMaterialRecord(materialId, materialMap) {
+  if (materialId == null || materialMap.has(materialId)) {
+    return;
+  }
+
+  const record = Materials.get(materialId);
+  if (!record) {
+    return;
+  }
+
+  const { material, type } = record;
+  const metadata = typeof Materials.getMetadata === 'function' ? Materials.getMetadata(materialId) : { name: `Material ${materialId}`, textures: {} };
+
+  materialMap.set(materialId, {
+    id: materialId,
+    type,
+    name: metadata.name || `Material ${materialId}`,
+    parameters: {
+      color: Array.from(material.color || []),
+      roughness: material.roughness,
+      metalness: material.metalness,
+      emissive: Array.from((material.emissive && material.emissive.subarray ? material.emissive.subarray(0, 3) : [0, 0, 0])),
+      occlusionStrength: material.occlusionStrength,
+    },
+    textures: { ...(metadata.textures || {}) },
+  });
+}
 
 // Serialize an Instance hierarchy to JSON.
 // Only serializes own enumerable properties (excluding engine internals),
 // attributes and child relationships. Each node receives a stable GUID.
 export function serialize(root) {
+  const meshAssets = new Map();
+  const materialMap = new Map();
+
+  const collectMaterial = id => collectMaterialRecord(id, materialMap);
+
   function serializeInst(inst) {
     if (!inst.guid) inst.guid = guid();
 
@@ -33,12 +138,46 @@ export function serialize(root) {
       node.properties[k] = v;
     }
 
+    if (isMeshInstance(inst)) {
+      const meshGuid = serializeMeshAsset(inst.mesh, meshAssets, collectMaterial);
+      const materials = [];
+      if (inst.mesh && Array.isArray(inst.mesh.primitives)) {
+        for (let i = 0; i < inst.mesh.primitives.length; i += 1) {
+          const materialId = inst.getMaterialForPrimitive(i);
+          if (materialId != null) {
+            collectMaterial(materialId);
+            materials.push(materialId);
+          } else {
+            materials.push(null);
+          }
+        }
+      }
+
+      const transform = {
+        position: cloneVector(node.properties?.Position),
+        rotation: cloneVector(node.properties?.Rotation),
+        scale: cloneVector(node.properties?.Scale),
+      };
+
+      node.meshInstance = {
+        mesh: meshGuid,
+        materials,
+        transform,
+      };
+    }
+
     node.children = inst.Children.map(serializeInst);
     return node;
   }
 
-  const data = serializeInst(root);
-  return JSON.stringify(data);
+  const scene = {
+    version: SCENE_SERIALIZATION_VERSION,
+    root: serializeInst(root),
+    meshes: Array.from(meshAssets.values()),
+    materials: Array.from(materialMap.values()),
+  };
+
+  return JSON.stringify(scene);
 }
 
 export default serialize;


### PR DESCRIPTION
## Summary
- extend scene serialization to capture mesh assets, transforms, and referenced materials
- rebuild meshes and material assignments during deserialization with hooks for asset-backed textures
- cache CPU primitive data on meshes and track material metadata/asset references, exposing asset lookup utilities

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d47797cef4832ca8b0080b65deaff2