### PR TITLE
Implement virtualized explorer tree view

### DIFF
--- a/editor/app/main.js
+++ b/editor/app/main.js
@@ -24,47 +24,9 @@ function createPanel(title, description) {
   return container;
 }
 
-function createExplorerPanel(explorer, selection, shell) {
+function createExplorerPanel(explorer) {
   const container = createPanel('Explorer', 'Manage the scene hierarchy and quick actions.');
-  const actions = document.createElement('div');
-  actions.className = 'panel-actions';
-
-  const addModel = document.createElement('button');
-  addModel.textContent = 'Add Model';
-  addModel.addEventListener('click', () => {
-    explorer.addModel();
-    shell._setStatus('Model added to scene', 'positive', 1600);
-  });
-
-  const deleteSelected = document.createElement('button');
-  deleteSelected.textContent = 'Delete Selected';
-  deleteSelected.addEventListener('click', () => {
-    explorer.deleteSelected();
-    shell._setStatus('Selection cleared', 'warning', 1600);
-  });
-
-  actions.append(addModel, deleteSelected);
-  container.appendChild(actions);
-
-  const selectionInfo = document.createElement('div');
-  selectionInfo.className = 'hint';
-  container.appendChild(selectionInfo);
-
-  const updateSelectionInfo = () => {
-    const count = selection.get().length;
-    deleteSelected.disabled = count === 0;
-    selectionInfo.textContent = count
-      ? `${count} item${count === 1 ? '' : 's'} selected`
-      : 'No selection';
-  };
-  updateSelectionInfo();
-  selection.Changed.Connect(updateSelectionInfo);
-
-  const placeholder = document.createElement('div');
-  placeholder.className = 'panel-empty';
-  placeholder.textContent = 'Scene tree visualization is coming in Card 29.';
-  container.appendChild(placeholder);
-
+  container.appendChild(explorer.getElement());
   return container;
 }
 
@@ -343,7 +305,7 @@ export function bootstrap() {
   const viewportPane = document.createElement('div');
   viewportPane.className = 'viewport-pane';
 
-  const explorerPanel = createExplorerPanel(explorer, selection, shell);
+  const explorerPanel = createExplorerPanel(explorer);
   const propertiesPanel = createPropertiesPanel(properties, selection);
   const consolePanel = createConsolePanel(consolePane);
   const assetsPanel = createAssetsPanel(assetsPane, shell);

--- a/editor/panes/explorer.css
+++ b/editor/panes/explorer.css
@@ -1,0 +1,41 @@
+.explorer-pane {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.5rem 0;
+  min-height: 0;
+}
+
+.explorer-pane__search {
+  position: relative;
+}
+
+.explorer-pane__search input {
+  width: 100%;
+  padding: 0.45rem 0.75rem;
+  border-radius: 0.45rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(12, 16, 24, 0.85);
+  color: inherit;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.explorer-pane__search input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px rgba(91, 139, 255, 0.45);
+}
+
+.explorer-pane__tree {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.explorer-pane__status {
+  font-size: 0.75rem;
+  color: rgba(245, 247, 251, 0.65);
+}
+
+.explorer-pane__status strong {
+  color: rgba(245, 247, 251, 0.95);
+}

--- a/editor/panes/explorer.js
+++ b/editor/panes/explorer.js
@@ -1,23 +1,349 @@
-import { Instance } from '../../engine/core/index.js';
+import { Instance, Services, GetService } from '../../engine/core/index.js';
+import { TransformNode } from '../../engine/render/mesh/meshInstance.js';
+import { getWorkspace } from '../../engine/scene/workspace.js';
 import UndoService from '../services/undo.js';
 import { Selection } from '../services/selection.js';
+import VirtualTree from '../ui/tree/tree.js';
+import showContextMenu, { closeContextMenu } from '../ui/contextmenu.js';
 
-// Minimal Explorer pane logic providing creation and deletion actions
-// hooked into the undo service.
+const SERVICE_ORDER = [
+  'Workspace',
+  'Players',
+  'Lighting',
+  'ReplicatedStorage',
+  'ServerStorage',
+  'StarterGui',
+  'StarterPack',
+  'StarterPlayer',
+  'SoundService',
+  'MaterialService',
+  'RunService',
+  'UserInputService',
+  'TweenService',
+  'PhysicsService',
+  'CollectionService',
+];
+
+function isDescendant(target, candidate) {
+  if (!target || !candidate) return false;
+  let current = target.Parent;
+  while (current) {
+    if (current === candidate) return true;
+    current = current.Parent;
+  }
+  return false;
+}
+
+function defaultNameForClass(className) {
+  if (className === 'Folder') return 'Folder';
+  if (className === 'Model') return 'Model';
+  if (className === 'Part') return 'Part';
+  return className || 'Instance';
+}
+
+function createPlaceholderInstance(className) {
+  if (className === 'Part') {
+    const part = new TransformNode('Part');
+    part.Name = defaultNameForClass('Part');
+    return part;
+  }
+  const inst = new Instance(className);
+  inst.Name = defaultNameForClass(className);
+  return inst;
+}
+
 export default class Explorer {
   constructor(undo = new UndoService(), selection = new Selection()) {
     this.undo = undo;
     this.selection = selection;
-    this.nodes = new Set();
+    this._suspendSelection = false;
+    this._connections = new Map();
+    this._serviceSet = new Set();
+
+    this.hasDOM = typeof document !== 'undefined' && typeof document.createElement === 'function';
+    this._registered = new Set();
+
+    if (this.hasDOM) {
+      this.element = document.createElement('div');
+      this.element.className = 'explorer-pane';
+
+      this.search = document.createElement('div');
+      this.search.className = 'explorer-pane__search';
+      this.searchInput = document.createElement('input');
+      this.searchInput.type = 'search';
+      this.searchInput.placeholder = 'Search instances…';
+      this.search.appendChild(this.searchInput);
+      this.element.appendChild(this.search);
+
+      this.treeHost = document.createElement('div');
+      this.treeHost.className = 'explorer-pane__tree';
+      this.element.appendChild(this.treeHost);
+
+      this.status = document.createElement('div');
+      this.status.className = 'explorer-pane__status';
+      this.element.appendChild(this.status);
+
+      this.tree = new VirtualTree(this.treeHost, {
+        rowHeight: 24,
+        indent: 16,
+        getLabel: node => node?.Name ?? node?.ClassName ?? '',
+        getIcon: node => this._getIconForNode(node),
+      });
+
+      this.tree.on('selectionchange', ({ selection }) => this._syncSelectionFromTree(selection));
+      this.tree.on('rename', ({ node, name }) => this._renameNode(node, name));
+      this.tree.on('drop', ({ nodes, target }) => this._handleDrop(nodes, target));
+      this.tree.on('delete', ({ selection }) => {
+        if (selection?.length) this.deleteSelection();
+      });
+
+      this.tree.viewport.addEventListener('contextmenu', event => {
+        const entry = this.tree.getEntryFromElement(event.target);
+        if (entry && !this.selection.isSelected(entry.node)) {
+          this.tree.setSelection([entry.node]);
+          this._syncSelectionFromTree([entry.node]);
+        }
+        const node = entry?.node ?? null;
+        showContextMenu(event, this._buildContextMenu(node));
+      });
+
+      let searchTimer = null;
+      this.searchInput.addEventListener('input', () => {
+        window.clearTimeout(searchTimer);
+        searchTimer = window.setTimeout(() => {
+          this.tree.setFilter(this.searchInput.value);
+        }, 160);
+      });
+      this.searchInput.addEventListener('keydown', event => {
+        if (event.key === 'Escape' && this.searchInput.value) {
+          this.searchInput.value = '';
+          this.tree.setFilter('');
+          event.stopPropagation();
+        }
+      });
+    } else {
+      this.element = null;
+      this.status = null;
+      this.tree = {
+        setSelection: () => {},
+        refresh: () => {},
+        expand: () => {},
+        collapse: () => {},
+        expandPathTo: () => {},
+        beginRename: () => {},
+        setFilter: () => {},
+        dispose: () => {},
+        getChildren: node => (node?.Children ?? []),
+      };
+    }
+
+    this.services = this._buildServices();
+    if (this.hasDOM) {
+      this.tree.setData(this.services);
+      for (const service of this.services) {
+        this._watchHierarchy(service);
+      }
+    }
+
+    this.selectionConnection = this.selection.Changed.Connect(sel => {
+      this._syncSelectionFromService(sel);
+    });
+    this._syncSelectionFromService(this.selection.get());
+  }
+
+  dispose() {
+    closeContextMenu();
+    if (this.selectionConnection) this.selectionConnection.Disconnect();
+    for (const [node, connections] of this._connections.entries()) {
+      for (const conn of connections) {
+        conn?.Disconnect?.();
+      }
+    }
+    this._connections.clear();
+    this.tree.dispose();
+  }
+
+  getElement() {
+    return this.element;
+  }
+
+  _buildServices() {
+    const result = [];
+    this._serviceSet.clear();
+    for (const name of SERVICE_ORDER) {
+      const service = this._ensureService(name);
+      if (service && !result.includes(service)) {
+        result.push(service);
+        this._serviceSet.add(service);
+      }
+    }
+    return result;
+  }
+
+  _ensureService(name) {
+    if (name === 'Workspace') {
+      const workspace = getWorkspace();
+      workspace.Name = 'Workspace';
+      return workspace;
+    }
+    let service = GetService(name);
+    if (!service) {
+      service = new Instance(name);
+      service.Name = name;
+      if (Services && typeof Services.set === 'function') {
+        Services.set(name, service);
+      }
+    }
+    return service;
+  }
+
+  _watchHierarchy(node) {
+    if (!node || this._connections.has(node)) return;
+    const connections = [];
+    if (node.ChildAdded?.Connect) {
+      connections.push(node.ChildAdded.Connect(child => {
+        this._watchHierarchy(child);
+        this.tree.refresh();
+      }));
+    }
+    if (node.ChildRemoved?.Connect) {
+      connections.push(node.ChildRemoved.Connect(child => {
+        this._unwatch(child);
+        this.tree.refresh();
+      }));
+    }
+    if (node.AncestryChanged?.Connect) {
+      connections.push(node.AncestryChanged.Connect(() => {
+        this.tree.refresh();
+      }));
+    }
+    if (node.Changed?.Connect) {
+      connections.push(node.Changed.Connect(prop => {
+        if (prop === 'Name') {
+          this.tree.refresh();
+        }
+      }));
+    }
+    this._connections.set(node, connections);
+    const children = this.tree.getChildren(node) ?? [];
+    for (const child of children) {
+      this._watchHierarchy(child);
+    }
+  }
+
+  _unwatch(node) {
+    if (!node) return;
+    const connections = this._connections.get(node);
+    if (connections) {
+      for (const conn of connections) {
+        conn?.Disconnect?.();
+      }
+      this._connections.delete(node);
+    }
+    const children = this.tree.getChildren(node) ?? [];
+    for (const child of children) {
+      this._unwatch(child);
+    }
+  }
+
+  _syncSelectionFromTree(nodes) {
+    if (this._suspendSelection) return;
+    this._suspendSelection = true;
+    this.selection.set(nodes);
+    this._updateStatus();
+    this._suspendSelection = false;
+  }
+
+  _syncSelectionFromService(nodes) {
+    if (this._suspendSelection) return;
+    this._suspendSelection = true;
+    const list = Array.isArray(nodes) ? nodes : [];
+    if (list[0]) {
+      this.tree.expandPathTo(list[0]);
+    }
+    this.tree.setSelection(list);
+    this._updateStatus();
+    this._suspendSelection = false;
+  }
+
+  _updateStatus() {
+    if (!this.status) return;
+    const count = this.selection.get().length;
+    if (!count) {
+      this.status.textContent = 'No selection';
+      return;
+    }
+    this.status.innerHTML = `<strong>${count}</strong> item${count === 1 ? '' : 's'} selected`;
+  }
+
+  _renameNode(node, name) {
+    if (!node) return;
+    const command = this.undo.setProperty(node, 'Name', name);
+    this.undo.execute(command);
+    this.tree.refresh();
+  }
+
+  _handleDrop(nodes, target) {
+    if (!target || !Array.isArray(nodes) || nodes.length === 0) return;
+    const filtered = nodes.filter(node => node && node !== target && !isDescendant(target, node));
+    if (!filtered.length) return;
+    const commands = filtered.map(node => this.undo.reparent(node, target));
+    if (!commands.length) return;
+    if (commands.length === 1) {
+      this.undo.execute(commands[0]);
+    } else {
+      this.undo.execute({
+        undo: () => {
+          for (const cmd of [...commands].reverse()) cmd.undo();
+        },
+        redo: () => {
+          for (const cmd of commands) cmd.redo();
+        },
+      });
+    }
+    this.tree.expand(target);
+    this.selection.set(filtered);
+    this.tree.setSelection(filtered);
+    this.tree.refresh();
+  }
+
+  deleteSelection() {
+    const items = this.selection.get().filter(node => node && node.Parent);
+    if (!items.length) return;
+    const commands = items.map(node => this.undo.deleteInstance(node));
+    if (commands.length === 1) {
+      this.undo.execute(commands[0]);
+    } else {
+      this.undo.execute({
+        undo: () => {
+          for (const cmd of [...commands].reverse()) cmd.undo();
+        },
+        redo: () => {
+          for (const cmd of commands) cmd.redo();
+        },
+      });
+    }
+    this.selection.clear();
+    this.tree.setSelection([]);
+    this.tree.refresh();
   }
 
   register(inst) {
-    if (inst) this.nodes.add(inst);
+    if (!inst) return;
+    this._registered.add(inst);
+    if (this.hasDOM) {
+      this._watchHierarchy(inst);
+      this.tree.refresh();
+    }
   }
 
   unregister(inst) {
     if (!inst) return;
-    this.nodes.delete(inst);
+    this._registered.delete(inst);
+    if (this.hasDOM) {
+      this._unwatch(inst);
+      this.tree.refresh();
+    }
     if (this.selection.isSelected(inst)) {
       this.selection.remove(inst);
     }
@@ -26,13 +352,13 @@ export default class Explorer {
   click(inst, { additive = false, toggle = false } = {}) {
     if (!inst) {
       this.selection.clear();
+      if (this.hasDOM) this.tree.setSelection([]);
       return this.selection.get();
     }
 
-    this.register(inst);
-
     if (toggle && this.selection.isSelected(inst)) {
       this.selection.remove(inst);
+      if (this.hasDOM) this.tree.setSelection(this.selection.get());
       return this.selection.get();
     }
 
@@ -42,6 +368,7 @@ export default class Explorer {
       this.selection.set([inst]);
     }
 
+    if (this.hasDOM) this.tree.setSelection(this.selection.get());
     return this.selection.get();
   }
 
@@ -50,15 +377,232 @@ export default class Explorer {
   }
 
   addModel() {
-    const model = new Instance('Model');
-    this.undo.execute(this.undo.createInstance(model, null));
+    const target = this.selection.get()[0] ?? getWorkspace();
+    const model = createPlaceholderInstance('Model');
+    this.undo.execute(this.undo.createInstance(model, target));
+    if (this.hasDOM) {
+      this.tree.expand(target);
+      this.tree.setSelection([model]);
+    }
+    this.selection.set([model]);
+    this.tree.refresh();
     return model;
   }
 
   deleteSelected() {
-    for (const inst of this.selection.getSelection()) {
-      this.undo.execute(this.undo.deleteInstance(inst));
+    this.deleteSelection();
+  }
+
+  duplicateSelection() {
+    const items = this.selection.get().filter(Boolean);
+    if (!items.length) return;
+    const created = [];
+    const commands = [];
+    for (const item of items) {
+      const parent = item.Parent ?? getWorkspace();
+      const clone = this._cloneInstance(item);
+      created.push(clone);
+      commands.push(this.undo.createInstance(clone, parent));
     }
+    if (!commands.length) return;
+    if (commands.length === 1) {
+      this.undo.execute(commands[0]);
+    } else {
+      this.undo.execute({
+        undo: () => {
+          for (const cmd of [...commands].reverse()) cmd.undo();
+        },
+        redo: () => {
+          for (const cmd of commands) cmd.redo();
+        },
+      });
+    }
+    this.selection.set(created);
+    this.tree.setSelection(created);
+    if (created[0]?.Parent) {
+      this.tree.expand(created[0].Parent);
+    }
+    this.tree.refresh();
+  }
+
+  groupSelection() {
+    const items = this.selection.get().filter(Boolean);
+    if (items.length < 2) return;
+    const parent = this._findCommonParent(items) ?? getWorkspace();
+    const group = createPlaceholderInstance('Model');
+    group.Name = 'Group';
+    const originalParents = new Map();
+    for (const item of items) {
+      originalParents.set(item, item.Parent ?? null);
+    }
+    this.undo.execute({
+      undo: () => {
+        for (const item of [...items].reverse()) {
+          item.Parent = originalParents.get(item) ?? null;
+        }
+        group.Parent = null;
+      },
+      redo: () => {
+        group.Parent = parent;
+        for (const item of items) {
+          item.Parent = group;
+        }
+      },
+    });
+    this.selection.set([group]);
+    this.tree.setSelection([group]);
+    this.tree.expand(group);
+    this.tree.refresh();
+    this.tree.beginRename(group);
+  }
+
+  ungroupSelection() {
+    const items = this.selection.get().filter(node => node && this._isGroup(node));
+    if (!items.length) return;
+    const commands = items.map(group => {
+      const parent = group.Parent ?? null;
+      const children = [...(group.Children ?? [])];
+      return {
+        undo: () => {
+          group.Parent = parent;
+          for (const child of children) {
+            child.Parent = group;
+          }
+        },
+        redo: () => {
+          for (const child of children) {
+            child.Parent = parent;
+          }
+          group.Parent = null;
+        },
+      };
+    });
+    this.undo.execute({
+      undo: () => {
+        for (const cmd of [...commands].reverse()) cmd.undo();
+      },
+      redo: () => {
+        for (const cmd of commands) cmd.redo();
+      },
+    });
     this.selection.clear();
+    this.tree.setSelection([]);
+    this.tree.refresh();
+  }
+
+  collapseSelection(recursive = false) {
+    const items = this.selection.get().filter(Boolean);
+    if (!items.length) return;
+    for (const item of items) {
+      this.tree.collapse(item, recursive);
+    }
+  }
+
+  expandSelection(recursive = false) {
+    const items = this.selection.get().filter(Boolean);
+    if (!items.length) return;
+    for (const item of items) {
+      this.tree.expand(item, recursive);
+    }
+  }
+
+  _findCommonParent(nodes) {
+    if (!nodes.length) return null;
+    let parent = nodes[0].Parent ?? null;
+    for (const node of nodes) {
+      if (node.Parent !== parent) return null;
+    }
+    return parent;
+  }
+
+  _isGroup(node) {
+    if (!node) return false;
+    return node.ClassName === 'Model' || node.ClassName === 'Folder';
+  }
+
+  _cloneInstance(instance) {
+    if (!instance) return null;
+    let clone;
+    if (instance.ClassName === 'Part') {
+      clone = createPlaceholderInstance('Part');
+    } else {
+      try {
+        clone = new instance.constructor(instance.ClassName);
+      } catch (err) {
+        clone = createPlaceholderInstance(instance.ClassName);
+      }
+    }
+    clone.Name = `${instance.Name ?? instance.ClassName} Copy`;
+    if (instance.Attributes instanceof Map) {
+      for (const [key, value] of instance.Attributes.entries()) {
+        clone.SetAttribute?.(key, value);
+      }
+    }
+    const children = instance.Children ?? [];
+    for (const child of children) {
+      const childClone = this._cloneInstance(child);
+      if (childClone) childClone.Parent = clone;
+    }
+    return clone;
+  }
+
+  _buildContextMenu(node) {
+    const selection = this.selection.get();
+    const hasSelection = selection.length > 0;
+    const deletable = selection.some(item => item && item.Parent);
+    const canGroup = selection.length > 1;
+    const canUngroup = selection.some(item => this._isGroup(item));
+    return [
+      {
+        label: 'New',
+        children: [
+          { label: 'Model', action: () => this._createChild('Model', node) },
+          { label: 'Folder', action: () => this._createChild('Folder', node) },
+          { label: 'Part', action: () => this._createChild('Part', node) },
+        ],
+      },
+      { type: 'separator' },
+      { label: 'Duplicate', action: () => this.duplicateSelection(), disabled: !hasSelection },
+      { label: 'Delete', action: () => this.deleteSelection(), shortcut: 'Del', disabled: !deletable },
+      { type: 'separator' },
+      { label: 'Group', action: () => this.groupSelection(), disabled: !canGroup },
+      { label: 'Ungroup', action: () => this.ungroupSelection(), disabled: !canUngroup },
+      { type: 'separator' },
+      { label: 'Collapse', action: () => this.collapseSelection(false), disabled: !hasSelection },
+      { label: 'Collapse All', action: () => this.collapseSelection(true), disabled: !hasSelection },
+      { label: 'Expand', action: () => this.expandSelection(false), disabled: !hasSelection },
+      { label: 'Expand All', action: () => this.expandSelection(true), disabled: !hasSelection },
+    ];
+  }
+
+  _createChild(className, anchor) {
+    const selection = this.selection.get();
+    let parent = anchor ?? selection[0] ?? getWorkspace();
+    if (!parent || isDescendant(parent, anchor)) {
+      parent = getWorkspace();
+    }
+    const instance = createPlaceholderInstance(className);
+    this.undo.execute(this.undo.createInstance(instance, parent));
+    this.tree.expand(parent);
+    this.selection.set([instance]);
+    this.tree.setSelection([instance]);
+    this.tree.refresh();
+    this.tree.beginRename(instance);
+  }
+
+  _getIconForNode(node) {
+    if (!node) return null;
+    if (this._serviceSet.has(node)) {
+      if (node.ClassName === 'Lighting') return 'icon--light';
+      return 'icon--service';
+    }
+    const className = node.ClassName ?? '';
+    if (className === 'Folder' || className === 'Model') return 'icon--folder';
+    if (/script/i.test(className)) return 'icon--script';
+    if (/camera/i.test(className)) return 'icon--camera';
+    if (/light/i.test(className)) return 'icon--light';
+    if (/material/i.test(className)) return 'icon--material';
+    if (/part/i.test(className) || /mesh/i.test(className)) return 'icon--cube';
+    return 'icon--cube';
   }
 }

--- a/editor/ui/contextmenu.js
+++ b/editor/ui/contextmenu.js
@@ -1,0 +1,201 @@
+const ACTIVE_MENUS = new Set();
+let rootMenu = null;
+let outsideHandler = null;
+let keydownHandler = null;
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+class ContextMenu {
+  constructor(items, parent = null) {
+    this.parent = parent;
+    this.items = Array.isArray(items) ? items : [];
+    this.element = document.createElement('div');
+    this.element.className = 'contextmenu';
+    if (parent) {
+      this.element.classList.add('contextmenu--submenu');
+    }
+    this.submenus = new Set();
+    this._build();
+  }
+
+  _build() {
+    for (const item of this.items) {
+      if (!item) continue;
+      if (item.type === 'separator') {
+        const separator = document.createElement('div');
+        separator.className = 'contextmenu__separator';
+        this.element.appendChild(separator);
+        continue;
+      }
+
+      const wrapper = document.createElement('div');
+      wrapper.className = 'contextmenu__item';
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'contextmenu__button';
+      button.textContent = item.label ?? '';
+      if (item.shortcut) {
+        const shortcut = document.createElement('span');
+        shortcut.className = 'contextmenu__shortcut';
+        shortcut.textContent = item.shortcut;
+        button.appendChild(shortcut);
+      }
+      if (item.disabled) {
+        wrapper.classList.add('is-disabled');
+        button.disabled = true;
+      }
+      wrapper.appendChild(button);
+
+      if (Array.isArray(item.children) && item.children.length > 0) {
+        wrapper.classList.add('contextmenu__item--submenu');
+        const arrow = document.createElement('span');
+        arrow.className = 'contextmenu__arrow';
+        button.appendChild(arrow);
+        const submenu = new ContextMenu(item.children, this);
+        this.submenus.add(submenu);
+        wrapper.addEventListener('pointerenter', () => {
+          this._closeSubmenusExcept(submenu);
+          submenu.openSubmenu(wrapper);
+        });
+        wrapper.addEventListener('pointerdown', event => {
+          event.preventDefault();
+        });
+      } else if (!item.disabled) {
+        button.addEventListener('click', () => {
+          closeAllMenus();
+          if (typeof item.action === 'function') {
+            item.action();
+          }
+        });
+      }
+
+      this.element.appendChild(wrapper);
+    }
+  }
+
+  _closeSubmenusExcept(exception) {
+    for (const submenu of this.submenus) {
+      if (submenu !== exception) submenu.close();
+    }
+  }
+
+  openAt(x, y) {
+    if (!document.body.contains(this.element)) {
+      document.body.appendChild(this.element);
+    }
+    this.element.style.minWidth = '160px';
+    this.element.style.opacity = '0';
+    this.element.style.pointerEvents = 'none';
+    this.element.style.left = '0px';
+    this.element.style.top = '0px';
+    this.element.style.visibility = 'hidden';
+    requestAnimationFrame(() => {
+      const rect = this.element.getBoundingClientRect();
+      const viewportWidth = window.innerWidth;
+      const viewportHeight = window.innerHeight;
+      const targetX = clamp(x, 8, viewportWidth - rect.width - 8);
+      const targetY = clamp(y, 8, viewportHeight - rect.height - 8);
+      this.element.style.left = `${targetX}px`;
+      this.element.style.top = `${targetY}px`;
+      this.element.style.visibility = 'visible';
+      this.element.style.opacity = '1';
+      this.element.style.pointerEvents = 'auto';
+      ACTIVE_MENUS.add(this);
+    });
+  }
+
+  openSubmenu(anchor) {
+    if (!document.body.contains(this.element)) {
+      document.body.appendChild(this.element);
+    }
+    const anchorRect = anchor.getBoundingClientRect();
+    const rect = this.element.getBoundingClientRect();
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+    let x = anchorRect.right + 4;
+    if (x + rect.width > viewportWidth) {
+      x = Math.max(8, anchorRect.left - rect.width - 4);
+    }
+    let y = anchorRect.top;
+    if (y + rect.height > viewportHeight) {
+      y = viewportHeight - rect.height - 8;
+    }
+    this.element.style.left = `${x}px`;
+    this.element.style.top = `${y}px`;
+    this.element.style.visibility = 'visible';
+    this.element.style.opacity = '1';
+    this.element.style.pointerEvents = 'auto';
+    ACTIVE_MENUS.add(this);
+  }
+
+  close() {
+    this._closeSubmenusExcept(null);
+    if (this.element && this.element.parentElement) {
+      this.element.parentElement.removeChild(this.element);
+    }
+    ACTIVE_MENUS.delete(this);
+  }
+}
+
+function closeAllMenus() {
+  for (const menu of Array.from(ACTIVE_MENUS)) {
+    menu.close();
+  }
+  ACTIVE_MENUS.clear();
+  if (outsideHandler) {
+    document.removeEventListener('pointerdown', outsideHandler, true);
+    outsideHandler = null;
+  }
+  if (keydownHandler) {
+    document.removeEventListener('keydown', keydownHandler, true);
+    keydownHandler = null;
+  }
+  rootMenu = null;
+}
+
+function ensureGlobalHandlers() {
+  if (!outsideHandler) {
+    outsideHandler = event => {
+      if (!rootMenu) return;
+      const target = event.target;
+      for (const menu of ACTIVE_MENUS) {
+        if (menu.element.contains(target)) {
+          return;
+        }
+      }
+      closeAllMenus();
+    };
+    document.addEventListener('pointerdown', outsideHandler, true);
+  }
+  if (!keydownHandler) {
+    keydownHandler = event => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeAllMenus();
+      }
+    };
+    document.addEventListener('keydown', keydownHandler, true);
+  }
+}
+
+export function showContextMenu(position, items) {
+  const { x, y } = position instanceof Event
+    ? (() => {
+      position.preventDefault();
+      return { x: position.clientX, y: position.clientY };
+    })()
+    : position;
+  closeAllMenus();
+  rootMenu = new ContextMenu(items, null);
+  ensureGlobalHandlers();
+  rootMenu.openAt(x, y);
+  return rootMenu;
+}
+
+export function closeContextMenu() {
+  closeAllMenus();
+}
+
+export default showContextMenu;

--- a/editor/ui/icons.css
+++ b/editor/ui/icons.css
@@ -65,3 +65,33 @@
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M4 4h7l2 2h7a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2zm8 5a3 3 0 1 0 0 6 3 3 0 0 0 0-6zm0 2a1 1 0 1 1 0 2 1 1 0 0 1 0-2z'/%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M4 4h7l2 2h7a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2zm8 5a3 3 0 1 0 0 6 3 3 0 0 0 0-6zm0 2a1 1 0 1 1 0 2 1 1 0 0 1 0-2z'/%3E%3C/svg%3E");
 }
+
+.icon--cube {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M12 3l8 4.5v9L12 21l-8-4.5v-9L12 3zm0 2.2L6 7.6v6.8l6 3.4 6-3.4V7.6L12 5.2zm0 2.6l3.8 2.1v4.2L12 16.3 8.2 14v-4.2L12 7.8z'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M12 3l8 4.5v9L12 21l-8-4.5v-9L12 3zm0 2.2L6 7.6v6.8l6 3.4 6-3.4V7.6L12 5.2zm0 2.6l3.8 2.1v4.2L12 16.3 8.2 14v-4.2L12 7.8z'/%3E%3C/svg%3E");
+}
+
+.icon--light {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M12 3a5 5 0 0 1 5 5c0 1.9-.84 3.25-2.12 4.24-.24.18-.38.47-.38.78V15a2 2 0 0 1-2 2h-1v2h2v2H10v-2h2v-2h-1a2 2 0 0 1-2-2v-2.98c0-.31-.14-.6-.38-.78A5 5 0 0 1 7 8a5 5 0 0 1 5-5z'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M12 3a5 5 0 0 1 5 5c0 1.9-.84 3.25-2.12 4.24-.24.18-.38.47-.38.78V15a2 2 0 0 1-2 2h-1v2h2v2H10v-2h2v-2h-1a2 2 0 0 1-2-2v-2.98c0-.31-.14-.6-.38-.78A5 5 0 0 1 7 8a5 5 0 0 1 5-5z'/%3E%3C/svg%3E");
+}
+
+.icon--camera {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M4 6h3l1-2h8l1 2h3a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2zm8 3a4 4 0 1 0 0 8 4 4 0 0 0 0-8zm0 2.5a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M4 6h3l1-2h8l1 2h3a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2zm8 3a4 4 0 1 0 0 8 4 4 0 0 0 0-8zm0 2.5a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z'/%3E%3C/svg%3E");
+}
+
+.icon--material {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M12 3a9 9 0 1 1 0 18 9 9 0 0 1 0-18zm0 2a7 7 0 0 0-6.93 6h4.18a3 3 0 0 1 2.75-2 3 3 0 0 1 3 3v4.9A7 7 0 0 0 12 5zm3 7a3 3 0 0 0-3-3 3 3 0 0 0-2.83 2H5.07a7 7 0 0 0 9.93 6.12V12z'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M12 3a9 9 0 1 1 0 18 9 9 0 0 1 0-18zm0 2a7 7 0 0 0-6.93 6h4.18a3 3 0 0 1 2.75-2 3 3 0 0 1 3 3v4.9A7 7 0 0 0 12 5zm3 7a3 3 0 0 0-3-3 3 3 0 0 0-2.83 2H5.07a7 7 0 0 0 9.93 6.12V12z'/%3E%3C/svg%3E");
+}
+
+.icon--script {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M9 4H7a2 2 0 0 0-2 2v3a1 1 0 0 1-1 1H3v2h1a1 1 0 0 1 1 1v3a2 2 0 0 0 2 2h2v-2H7v-3a3 3 0 0 0-3-3 3 3 0 0 0 3-3V6h2V4zm6 0v2h2v3a3 3 0 0 0 3 3 3 3 0 0 0-3 3v3h-2v2h2a2 2 0 0 0 2-2v-3a1 1 0 0 1 1-1h1v-2h-1a1 1 0 0 1-1-1V6a2 2 0 0 0-2-2h-2z'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M9 4H7a2 2 0 0 0-2 2v3a1 1 0 0 1-1 1H3v2h1a1 1 0 0 1 1 1v3a2 2 0 0 0 2 2h2v-2H7v-3a3 3 0 0 0-3-3 3 3 0 0 0 3-3V6h2V4zm6 0v2h2v3a3 3 0 0 0 3 3 3 3 0 0 0-3 3v3h-2v2h2a2 2 0 0 0 2-2v-3a1 1 0 0 1 1-1h1v-2h-1a1 1 0 0 1-1-1V6a2 2 0 0 0-2-2h-2z'/%3E%3C/svg%3E");
+}
+
+.icon--service {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M4 4h16a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2zm0 9h16a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2zm3-7a1 1 0 1 0 0 2 1 1 0 0 0 0-2zm0 9a1 1 0 1 0 0 2 1 1 0 0 0 0-2zm4-7h8v2h-8V9zm0 9h8v2h-8v-2z'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M4 4h16a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2zm0 9h16a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2zm3-7a1 1 0 1 0 0 2 1 1 0 0 0 0-2zm0 9a1 1 0 1 0 0 2 1 1 0 0 0 0-2zm4-7h8v2h-8V9zm0 9h8v2h-8v-2z'/%3E%3C/svg%3E");
+}

--- a/editor/ui/tree/tree.css
+++ b/editor/ui/tree/tree.css
@@ -1,0 +1,203 @@
+.virtual-tree {
+  --tree-row-height: 24px;
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background: var(--panel);
+  border-radius: 0.45rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.45);
+}
+
+.virtual-tree.is-dragging {
+  cursor: grabbing;
+}
+
+.virtual-tree__content {
+  position: relative;
+  min-height: 100%;
+}
+
+.virtual-tree__row {
+  position: absolute;
+  inset: 0 0 auto 0;
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding-right: 1rem;
+  font-size: 0.85rem;
+  line-height: 1;
+  color: rgba(244, 246, 251, 0.88);
+  cursor: default;
+  user-select: none;
+  white-space: nowrap;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.virtual-tree__row:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.virtual-tree__row.is-selected {
+  background: rgba(91, 139, 255, 0.18);
+  color: #f5f7ff;
+}
+
+.virtual-tree__row.is-selected:hover {
+  background: rgba(91, 139, 255, 0.24);
+}
+
+.virtual-tree__row.is-focused:not(.is-selected) {
+  background: rgba(91, 139, 255, 0.1);
+}
+
+.virtual-tree__row.has-match:not(.is-selected) .virtual-tree__label {
+  color: #f7f9ff;
+}
+
+.virtual-tree__toggle {
+  flex: 0 0 auto;
+  width: 1.1rem;
+  height: 1.1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: none;
+  color: inherit;
+  cursor: pointer;
+  border-radius: 0.25rem;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.virtual-tree__toggle:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.virtual-tree__toggle::before {
+  content: '\25B8';
+  font-size: 0.85rem;
+  transform: translateX(1px);
+}
+
+.virtual-tree__toggle.is-expanded::before {
+  content: '\25BE';
+  transform: translateY(-1px);
+}
+
+.virtual-tree__icon {
+  flex: 0 0 auto;
+  width: 1rem;
+  height: 1rem;
+  opacity: 0.85;
+  color: currentColor;
+}
+
+.virtual-tree__label {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.virtual-tree__highlight {
+  background: rgba(91, 139, 255, 0.28);
+  color: inherit;
+  padding: 0 0.1rem;
+  border-radius: 0.2rem;
+}
+
+.virtual-tree__rename {
+  width: 100%;
+  font: inherit;
+  color: inherit;
+  background: rgba(9, 12, 20, 0.9);
+  border: 1px solid rgba(91, 139, 255, 0.55);
+  border-radius: 0.3rem;
+  padding: 0.25rem 0.35rem;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+}
+
+.virtual-tree__drop-indicator {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2px;
+  margin-top: -1px;
+  background: var(--accent);
+  box-shadow: 0 0 0 1px rgba(12, 18, 32, 0.25);
+  pointer-events: none;
+  z-index: 10;
+}
+
+/* Context menu styling */
+.contextmenu {
+  position: fixed;
+  z-index: 10000;
+  min-width: 160px;
+  padding: 0.35rem 0;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(180deg, rgba(20, 26, 36, 0.98), rgba(12, 16, 24, 0.98));
+  box-shadow: var(--shadow-2);
+  backdrop-filter: blur(12px);
+}
+
+.contextmenu__item {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+}
+
+.contextmenu__item.is-disabled {
+  opacity: 0.45;
+}
+
+.contextmenu__button {
+  width: 100%;
+  border: none;
+  background: none;
+  color: inherit;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.4rem 0.9rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.contextmenu__button:hover:not(:disabled) {
+  background: rgba(91, 139, 255, 0.22);
+}
+
+.contextmenu__item.is-disabled .contextmenu__button {
+  cursor: default;
+}
+
+.contextmenu__shortcut {
+  opacity: 0.6;
+  font-size: 0.75rem;
+}
+
+.contextmenu__arrow {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  margin-left: 0.5rem;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M9 6l6 6-6 6'/%3E%3C/svg%3E") center / contain no-repeat;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M9 6l6 6-6 6'/%3E%3C/svg%3E") center / contain no-repeat;
+  background: currentColor;
+  opacity: 0.7;
+}
+
+.contextmenu__separator {
+  height: 1px;
+  margin: 0.25rem 0.35rem;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.contextmenu--submenu {
+  position: fixed;
+  margin-left: 0.35rem;
+}

--- a/editor/ui/tree/tree.js
+++ b/editor/ui/tree/tree.js
@@ -1,0 +1,692 @@
+let nodeIdCounter = 0;
+
+function defaultGetChildren(node) {
+  if (!node) return [];
+  if (typeof node.GetChildren === 'function') {
+    return node.GetChildren();
+  }
+  if (Array.isArray(node.Children)) {
+    return node.Children;
+  }
+  return [];
+}
+
+function defaultGetLabel(node) {
+  if (!node) return '';
+  if (typeof node.getLabel === 'function') return node.getLabel();
+  return node.Name ?? node.ClassName ?? '';
+}
+
+function escapeHtml(text) {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function renderHighlightedText(element, text, filter) {
+  if (!filter) {
+    element.textContent = text;
+    return;
+  }
+  const lower = text.toLowerCase();
+  const idx = lower.indexOf(filter.toLowerCase());
+  if (idx === -1) {
+    element.textContent = text;
+    return;
+  }
+  const before = text.slice(0, idx);
+  const match = text.slice(idx, idx + filter.length);
+  const after = text.slice(idx + filter.length);
+  element.innerHTML = `${escapeHtml(before)}<mark class="virtual-tree__highlight">${escapeHtml(match)}</mark>${escapeHtml(after)}`;
+}
+
+class VirtualTree {
+  constructor(hostElement, options = {}) {
+    this.hostElement = hostElement;
+    this.options = options;
+    this.rowHeight = options.rowHeight ?? 22;
+    this.indent = options.indent ?? 14;
+    this.multiSelect = options.multiSelect !== false;
+    this.getChildren = options.getChildren ?? defaultGetChildren;
+    this.getLabel = options.getLabel ?? defaultGetLabel;
+    this.getIcon = options.getIcon ?? (() => null);
+    this.getId = options.getId ?? (node => {
+      if (!node) return null;
+      if (!node.__virtualTreeId) {
+        Object.defineProperty(node, '__virtualTreeId', {
+          value: `node-${nodeIdCounter += 1}`,
+          enumerable: false,
+          configurable: false,
+          writable: false,
+        });
+      }
+      return node.__virtualTreeId;
+    });
+    this.isExpandable = options.isExpandable ?? (node => this.getChildren(node).length > 0);
+
+    this.roots = [];
+    this.visibleEntries = [];
+    this.expanded = new Set();
+    this.selection = [];
+    this.selectionSet = new Set();
+    this.anchorId = null;
+    this.focusedId = null;
+    this.filterText = '';
+    this.filterMatches = new Set();
+    this._rowPool = [];
+    this._rowToEntry = new Map();
+    this._events = new EventTarget();
+    this._dragState = null;
+    this._pressState = null;
+
+    this.viewport = document.createElement('div');
+    this.viewport.className = 'virtual-tree';
+    this.viewport.tabIndex = 0;
+    this.content = document.createElement('div');
+    this.content.className = 'virtual-tree__content';
+    this.viewport.appendChild(this.content);
+    this.hostElement.appendChild(this.viewport);
+
+    this.dropIndicator = document.createElement('div');
+    this.dropIndicator.className = 'virtual-tree__drop-indicator';
+    this.viewport.appendChild(this.dropIndicator);
+    this.dropIndicator.hidden = true;
+
+    this._boundRender = () => this._render();
+    this._boundPointerMove = event => this._handlePointerMove(event);
+    this._boundPointerUp = event => this._handlePointerUp(event);
+    this._boundPointerCancel = event => this._handlePointerCancel(event);
+
+    this.viewport.addEventListener('scroll', this._boundRender);
+    this.viewport.addEventListener('click', event => this._handleClick(event));
+    this.viewport.addEventListener('dblclick', event => this._handleDoubleClick(event));
+    this.viewport.addEventListener('keydown', event => this._handleKeyDown(event));
+    this.viewport.addEventListener('pointerdown', event => this._handlePointerDown(event));
+
+    this.resizeObserver = null;
+    if (typeof ResizeObserver !== 'undefined') {
+      this.resizeObserver = new ResizeObserver(() => this._render());
+      this.resizeObserver.observe(this.viewport);
+    } else {
+      window.addEventListener('resize', this._boundRender);
+    }
+  }
+
+  dispose() {
+    this.viewport.removeEventListener('scroll', this._boundRender);
+    this.viewport.remove();
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+    } else {
+      window.removeEventListener('resize', this._boundRender);
+    }
+  }
+
+  on(eventName, callback) {
+    const handler = evt => callback?.(evt.detail);
+    this._events.addEventListener(eventName, handler);
+    return () => this._events.removeEventListener(eventName, handler);
+  }
+
+  emit(eventName, detail = {}) {
+    this._events.dispatchEvent(new CustomEvent(eventName, { detail }));
+  }
+
+  setData(roots = []) {
+    this.roots = Array.isArray(roots) ? roots : [];
+    this.visibleEntries = [];
+    this.expanded.clear();
+    for (const root of this.roots) {
+      if (root) this.expanded.add(this.getId(root));
+    }
+    this.refresh();
+  }
+
+  refresh() {
+    this._buildVisibleEntries();
+    this._updateFilterMatches();
+    this._render();
+  }
+
+  setFilter(text) {
+    this.filterText = (text ?? '').trim();
+    this._updateFilterMatches();
+    this._render();
+  }
+
+  setSelection(nodes, { anchor } = {}) {
+    const list = Array.isArray(nodes) ? nodes.filter(Boolean) : [];
+    this.selection = list;
+    this.selectionSet = new Set(list);
+    const anchorNode = anchor ?? list[0] ?? null;
+    this.anchorId = anchorNode ? this.getId(anchorNode) : null;
+    this.focusedId = this.anchorId;
+    this._render();
+  }
+
+  getSelection() {
+    return [...this.selection];
+  }
+
+  toggle(node) {
+    if (!node) return;
+    const id = this.getId(node);
+    if (this.expanded.has(id)) {
+      this.expanded.delete(id);
+    } else {
+      this.expanded.add(id);
+    }
+    this.refresh();
+  }
+
+  expand(node, recursive = false) {
+    if (!node) return;
+    const id = this.getId(node);
+    this.expanded.add(id);
+    if (recursive) {
+      for (const child of this.getChildren(node)) {
+        this.expand(child, true);
+      }
+    }
+    this.refresh();
+  }
+
+  collapse(node, recursive = false) {
+    if (!node) return;
+    const id = this.getId(node);
+    this.expanded.delete(id);
+    if (recursive) {
+      for (const child of this.getChildren(node)) {
+        this.collapse(child, true);
+      }
+    }
+    this.refresh();
+  }
+
+  expandPathTo(node) {
+    if (!node) return;
+    let current = node.Parent ?? null;
+    while (current) {
+      this.expanded.add(this.getId(current));
+      current = current.Parent ?? null;
+    }
+    this.refresh();
+  }
+
+  scrollTo(node) {
+    if (!node) return;
+    const id = this.getId(node);
+    const entry = this.visibleEntries.find(item => this.getId(item.node) === id);
+    if (!entry) return;
+    const top = entry.index * this.rowHeight;
+    const bottom = top + this.rowHeight;
+    const scrollTop = this.viewport.scrollTop;
+    const height = this.viewport.clientHeight;
+    if (top < scrollTop) {
+      this.viewport.scrollTop = top;
+    } else if (bottom > scrollTop + height) {
+      this.viewport.scrollTop = bottom - height;
+    }
+    this._render();
+  }
+
+  beginRename(node) {
+    if (!node) return;
+    this.expandPathTo(node);
+    this.scrollTo(node);
+    requestAnimationFrame(() => {
+      this._startInlineRename(node);
+    });
+  }
+
+  getEntryFromElement(element) {
+    const row = element?.closest('.virtual-tree__row');
+    if (!row) return null;
+    return this._rowToEntry.get(row) ?? null;
+  }
+
+  _buildVisibleEntries() {
+    this.visibleEntries = [];
+    const pushNode = (node, depth, parent = null) => {
+      if (!node) return;
+      const id = this.getId(node);
+      const children = this.getChildren(node) || [];
+      const entry = {
+        node,
+        id,
+        depth,
+        parent,
+        hasChildren: Boolean(children.length),
+        index: this.visibleEntries.length,
+      };
+      this.visibleEntries.push(entry);
+      if (entry.hasChildren && this.expanded.has(id)) {
+        for (const child of children) {
+          pushNode(child, depth + 1, node);
+        }
+      }
+    };
+
+    for (const root of this.roots) {
+      pushNode(root, 0, null);
+    }
+  }
+
+  _updateFilterMatches() {
+    this.filterMatches = new Set();
+    const filter = this.filterText.toLowerCase();
+    if (!filter) return;
+    const visit = node => {
+      if (!node) return;
+      const label = (this.getLabel(node) ?? '').toLowerCase();
+      if (label.includes(filter)) {
+        this.filterMatches.add(this.getId(node));
+      }
+      for (const child of this.getChildren(node)) {
+        visit(child);
+      }
+    };
+    for (const root of this.roots) {
+      visit(root);
+    }
+  }
+
+  _ensureRowPool(count) {
+    while (this._rowPool.length < count) {
+      const row = document.createElement('div');
+      row.className = 'virtual-tree__row';
+      row.style.height = `${this.rowHeight}px`;
+      const toggle = document.createElement('button');
+      toggle.type = 'button';
+      toggle.className = 'virtual-tree__toggle';
+      const icon = document.createElement('span');
+      icon.className = 'virtual-tree__icon';
+      const label = document.createElement('span');
+      label.className = 'virtual-tree__label';
+      row.append(toggle, icon, label);
+      this.content.appendChild(row);
+      this._rowPool.push(row);
+    }
+  }
+
+  _render() {
+    const total = this.visibleEntries.length;
+    this.content.style.height = `${Math.max(0, total * this.rowHeight)}px`;
+    const viewportHeight = this.viewport.clientHeight || 0;
+    const scrollTop = this.viewport.scrollTop || 0;
+    const startIndex = Math.max(0, Math.floor(scrollTop / this.rowHeight) - 2);
+    const endIndex = Math.min(total, Math.ceil((scrollTop + viewportHeight) / this.rowHeight) + 2);
+    const needed = Math.max(0, endIndex - startIndex);
+
+    this._ensureRowPool(needed);
+    this._rowToEntry.clear();
+
+    for (let i = 0; i < this._rowPool.length; i += 1) {
+      const row = this._rowPool[i];
+      if (i < needed) {
+        const entry = this.visibleEntries[startIndex + i];
+        this._updateRow(row, entry);
+        row.style.display = '';
+        row.style.transform = `translateY(${(startIndex + i) * this.rowHeight}px)`;
+        this._rowToEntry.set(row, entry);
+      } else {
+        row.style.display = 'none';
+        this._rowToEntry.delete(row);
+      }
+    }
+  }
+
+  _updateRow(row, entry) {
+    const { node, depth, hasChildren } = entry;
+    row.style.paddingLeft = `${8 + depth * this.indent}px`;
+    row.dataset.nodeId = entry.id;
+    row.dataset.depth = String(depth);
+    row.classList.toggle('is-selected', this.selectionSet.has(node));
+    row.classList.toggle('is-focused', this.focusedId === entry.id && this.viewport === document.activeElement);
+    row.classList.toggle('has-children', hasChildren);
+    row.classList.toggle('has-match', this.filterMatches.has(entry.id));
+
+    const [toggle, iconEl, labelEl] = row.children;
+    if (toggle) {
+      toggle.hidden = !hasChildren;
+      toggle.setAttribute('aria-hidden', hasChildren ? 'false' : 'true');
+      toggle.classList.toggle('is-expanded', this.expanded.has(entry.id));
+    }
+
+    if (iconEl) {
+      const iconClass = this.getIcon(node);
+      iconEl.className = 'virtual-tree__icon';
+      if (iconClass) {
+        iconEl.classList.add('icon', iconClass);
+      }
+    }
+
+    const labelText = this.getLabel(node) ?? '';
+    renderHighlightedText(labelEl, labelText, this.filterText);
+  }
+
+  _handleClick(event) {
+    if (event.defaultPrevented) return;
+    const row = event.target.closest('.virtual-tree__row');
+    if (!row) return;
+    const entry = this._rowToEntry.get(row);
+    if (!entry) return;
+
+    if (event.target.closest('.virtual-tree__toggle')) {
+      this.toggle(entry.node);
+      return;
+    }
+
+    const { ctrlKey, metaKey, shiftKey } = event;
+    this._applySelection(entry, { additive: ctrlKey || metaKey, toggle: ctrlKey || metaKey, range: shiftKey });
+    this.emit('selectionchange', { selection: this.getSelection() });
+    this.viewport.focus({ preventScroll: true });
+  }
+
+  _applySelection(entry, { additive = false, toggle = false, range = false } = {}) {
+    if (!entry) return;
+    const node = entry.node;
+    if (range && this.anchorId) {
+      const anchorIndex = this.visibleEntries.findIndex(item => this.getId(item.node) === this.anchorId);
+      const currentIndex = entry.index;
+      if (anchorIndex !== -1) {
+        const [start, end] = anchorIndex < currentIndex
+          ? [anchorIndex, currentIndex]
+          : [currentIndex, anchorIndex];
+        const rangeNodes = [];
+        for (let i = start; i <= end; i += 1) {
+          rangeNodes.push(this.visibleEntries[i].node);
+        }
+        this.selection = rangeNodes;
+        this.selectionSet = new Set(rangeNodes);
+        this.focusedId = entry.id;
+        return;
+      }
+    }
+
+    if (toggle && this.selectionSet.has(node)) {
+      this.selection = this.selection.filter(item => item !== node);
+      this.selectionSet.delete(node);
+      this.focusedId = entry.id;
+      if (this.selection.length === 0) {
+        this.anchorId = null;
+      }
+      this._render();
+      return;
+    }
+
+    if (additive) {
+      if (!this.selectionSet.has(node)) {
+        this.selection.push(node);
+        this.selectionSet.add(node);
+      }
+    } else {
+      this.selection = [node];
+      this.selectionSet = new Set([node]);
+    }
+    this.anchorId = this.getId(node);
+    this.focusedId = this.anchorId;
+    this._render();
+  }
+
+  _handleDoubleClick(event) {
+    const row = event.target.closest('.virtual-tree__row');
+    if (!row) return;
+    const entry = this._rowToEntry.get(row);
+    if (!entry) return;
+    if (entry.hasChildren) {
+      this.toggle(entry.node);
+    }
+  }
+
+  _handleKeyDown(event) {
+    if (event.defaultPrevented) return;
+    const key = event.key;
+    if (key === 'ArrowDown') {
+      event.preventDefault();
+      this._moveFocus(1, event.shiftKey);
+    } else if (key === 'ArrowUp') {
+      event.preventDefault();
+      this._moveFocus(-1, event.shiftKey);
+    } else if (key === 'ArrowLeft') {
+      event.preventDefault();
+      this._handleCollapseKey();
+    } else if (key === 'ArrowRight') {
+      event.preventDefault();
+      this._handleExpandKey();
+    } else if (key === 'Home') {
+      event.preventDefault();
+      this._moveFocusToIndex(0, event.shiftKey);
+    } else if (key === 'End') {
+      event.preventDefault();
+      this._moveFocusToIndex(this.visibleEntries.length - 1, event.shiftKey);
+    } else if (key === 'a' && (event.ctrlKey || event.metaKey)) {
+      event.preventDefault();
+      this.selection = this.visibleEntries.map(entry => entry.node);
+      this.selectionSet = new Set(this.selection);
+      this.anchorId = this.selection.length ? this.getId(this.selection[0]) : null;
+      this.focusedId = this.anchorId;
+      this._render();
+      this.emit('selectionchange', { selection: this.getSelection() });
+    } else if (key === 'F2') {
+      event.preventDefault();
+      const node = this.selection[0];
+      if (node) this.beginRename(node);
+    } else if (key === 'Delete' || key === 'Backspace') {
+      event.preventDefault();
+      this.emit('delete', { selection: this.getSelection() });
+    }
+  }
+
+  _moveFocus(delta, extendSelection) {
+    if (!this.visibleEntries.length) return;
+    let index = 0;
+    if (this.focusedId) {
+      const currentIndex = this.visibleEntries.findIndex(entry => entry.id === this.focusedId);
+      index = currentIndex !== -1 ? currentIndex + delta : 0;
+    } else {
+      index = delta > 0 ? 0 : this.visibleEntries.length - 1;
+    }
+    index = Math.max(0, Math.min(this.visibleEntries.length - 1, index));
+    this._moveFocusToIndex(index, extendSelection);
+  }
+
+  _moveFocusToIndex(index, extendSelection) {
+    if (index < 0 || index >= this.visibleEntries.length) return;
+    const entry = this.visibleEntries[index];
+    this.focusedId = entry.id;
+    if (extendSelection) {
+      this._applySelection(entry, { range: true });
+    } else {
+      this.selection = [entry.node];
+      this.selectionSet = new Set(this.selection);
+      this.anchorId = entry.id;
+      this._render();
+      this.emit('selectionchange', { selection: this.getSelection() });
+    }
+    this.scrollTo(entry.node);
+  }
+
+  _handleCollapseKey() {
+    if (!this.focusedId) return;
+    const entry = this.visibleEntries.find(item => item.id === this.focusedId);
+    if (!entry) return;
+    if (this.expanded.has(entry.id) && entry.hasChildren) {
+      this.expanded.delete(entry.id);
+      this.refresh();
+    } else if (entry.parent) {
+      this.focusedId = this.getId(entry.parent);
+      this.anchorId = this.focusedId;
+      this.selection = [entry.parent];
+      this.selectionSet = new Set(this.selection);
+      this.scrollTo(entry.parent);
+      this._render();
+      this.emit('selectionchange', { selection: this.getSelection() });
+    }
+  }
+
+  _handleExpandKey() {
+    if (!this.focusedId) return;
+    const entry = this.visibleEntries.find(item => item.id === this.focusedId);
+    if (!entry) return;
+    if (entry.hasChildren) {
+      if (!this.expanded.has(entry.id)) {
+        this.expanded.add(entry.id);
+        this.refresh();
+      } else {
+        const children = this.getChildren(entry.node);
+        if (children.length) {
+          this.focusedId = this.getId(children[0]);
+          this.anchorId = this.focusedId;
+          this.selection = [children[0]];
+          this.selectionSet = new Set(this.selection);
+          this.scrollTo(children[0]);
+          this._render();
+          this.emit('selectionchange', { selection: this.getSelection() });
+        }
+      }
+    }
+  }
+
+  _startInlineRename(node) {
+    const entry = this.visibleEntries.find(item => item.node === node);
+    if (!entry) return;
+    const row = [...this._rowToEntry.entries()].find(([, value]) => value === entry)?.[0];
+    if (!row) return;
+    const labelEl = row.querySelector('.virtual-tree__label');
+    if (!labelEl) return;
+
+    const currentText = this.getLabel(node) ?? '';
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'virtual-tree__rename';
+    input.value = currentText;
+    input.addEventListener('keydown', evt => {
+      if (evt.key === 'Enter') {
+        evt.preventDefault();
+        input.blur();
+      } else if (evt.key === 'Escape') {
+        evt.preventDefault();
+        input.value = currentText;
+        input.blur();
+      }
+    });
+    input.addEventListener('blur', () => {
+      labelEl.innerHTML = '';
+      renderHighlightedText(labelEl, this.getLabel(node) ?? '', this.filterText);
+      const nextName = input.value.trim();
+      if (nextName && nextName !== currentText) {
+        this.emit('rename', { node, name: nextName });
+      }
+    });
+    labelEl.innerHTML = '';
+    labelEl.appendChild(input);
+    input.focus();
+    input.select();
+  }
+
+  _handlePointerDown(event) {
+    if (event.button !== 0) return;
+    const row = event.target.closest('.virtual-tree__row');
+    if (!row) return;
+    const entry = this._rowToEntry.get(row);
+    if (!entry) return;
+    this._pressState = {
+      entry,
+      startX: event.clientX,
+      startY: event.clientY,
+    };
+    window.addEventListener('pointermove', this._boundPointerMove, true);
+    window.addEventListener('pointerup', this._boundPointerUp, true);
+    window.addEventListener('pointercancel', this._boundPointerCancel, true);
+  }
+
+  _handlePointerMove(event) {
+    if (!this._pressState) return;
+    const dx = event.clientX - this._pressState.startX;
+    const dy = event.clientY - this._pressState.startY;
+    if (!this._dragState) {
+      if (Math.hypot(dx, dy) > 4) {
+        this._beginDrag(this._pressState.entry);
+      } else {
+        return;
+      }
+    }
+    if (this._dragState) {
+      this._updateDragTarget(event);
+    }
+  }
+
+  _beginDrag(entry) {
+    if (!entry) return;
+    if (!this.selectionSet.has(entry.node)) {
+      this.selection = [entry.node];
+      this.selectionSet = new Set(this.selection);
+      this.anchorId = entry.id;
+      this.focusedId = entry.id;
+      this._render();
+      this.emit('selectionchange', { selection: this.getSelection() });
+    }
+    this._dragState = {
+      nodes: this.getSelection(),
+      target: null,
+    };
+    this.viewport.classList.add('is-dragging');
+  }
+
+  _updateDragTarget(event) {
+    const rect = this.viewport.getBoundingClientRect();
+    const offsetY = event.clientY - rect.top + this.viewport.scrollTop;
+    if (!this.visibleEntries.length || offsetY < 0) {
+      this._setDropTarget(null);
+      return;
+    }
+    const index = Math.max(0, Math.min(this.visibleEntries.length - 1, Math.floor(offsetY / this.rowHeight)));
+    const entry = this.visibleEntries[index];
+    if (!entry) {
+      this._setDropTarget(null);
+      return;
+    }
+    this._setDropTarget(entry);
+  }
+
+  _setDropTarget(entry) {
+    if (!this._dragState) return;
+    if (!entry || this.selectionSet.has(entry.node)) {
+      this.dropIndicator.hidden = true;
+      this._dragState.target = null;
+      return;
+    }
+    this._dragState.target = entry.node;
+    this.dropIndicator.hidden = false;
+    this.dropIndicator.style.top = `${(entry.index + 1) * this.rowHeight}px`;
+  }
+
+  _handlePointerUp() {
+    if (this._dragState && this._dragState.target) {
+      this.emit('drop', {
+        nodes: this._dragState.nodes,
+        target: this._dragState.target,
+      });
+    }
+    this._cleanupPointerState();
+  }
+
+  _handlePointerCancel() {
+    this._cleanupPointerState();
+  }
+
+  _cleanupPointerState() {
+    this._pressState = null;
+    this._dragState = null;
+    this.dropIndicator.hidden = true;
+    this.viewport.classList.remove('is-dragging');
+    window.removeEventListener('pointermove', this._boundPointerMove, true);
+    window.removeEventListener('pointerup', this._boundPointerUp, true);
+    window.removeEventListener('pointercancel', this._boundPointerCancel, true);
+  }
+}
+
+export default VirtualTree;

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,8 @@
   <link rel="stylesheet" href="/editor/ui/theme.css" />
   <link rel="stylesheet" href="/editor/ui/icons.css" />
   <link rel="stylesheet" href="/editor/ui/dock/dock.css" />
+  <link rel="stylesheet" href="/editor/panes/explorer.css" />
+  <link rel="stylesheet" href="/editor/ui/tree/tree.css" />
 </head>
 <body>
   <script type="module" src="main.js"></script>


### PR DESCRIPTION
## Summary
- replace the explorer pane with a virtualized tree that mirrors the instance hierarchy, supports search filtering, inline rename, drag-and-drop reparenting, and context menus
- add a reusable VirtualTree component, lightweight context menu helper, and styling/icons for services, folders, lights, parts, scripts, and materials
- expose legacy Explorer APIs for tests while wiring the new pane into the editor shell and bundling the required stylesheets

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4aedbf37c832cb9b232f52f5b192c