### PR TITLE
feat: add property grid inspector with attribute editing

### DIFF
--- a/editor/app/main.js
+++ b/editor/app/main.js
@@ -30,125 +30,17 @@ function createExplorerPanel(explorer) {
   return container;
 }
 
-function createPropertiesPanel(properties, selection) {
+function createPropertiesPanel(properties) {
   const container = createPanel('Properties', 'Inspect and edit selection attributes.');
-  const section = document.createElement('div');
-  section.className = 'panel-section';
-  container.appendChild(section);
-
-  const nameField = document.createElement('div');
-  nameField.className = 'panel-field';
-  const nameLabel = document.createElement('span');
-  nameLabel.className = 'panel-field__label';
-  nameLabel.textContent = 'Name';
-  const nameInputWrap = document.createElement('div');
-  nameInputWrap.className = 'panel-field__input';
-  const nameInput = document.createElement('input');
-  nameInput.type = 'text';
-  nameInput.placeholder = 'No selection';
-  nameInput.disabled = true;
-  nameInputWrap.appendChild(nameInput);
-  nameField.append(nameLabel, nameInputWrap);
-  section.appendChild(nameField);
-
-  const vectorFields = {};
-  for (const prop of ['Position', 'Rotation', 'Scale']) {
-    const field = document.createElement('div');
-    field.className = 'panel-field';
-    const label = document.createElement('span');
-    label.className = 'panel-field__label';
-    label.textContent = prop;
-    const inputsWrap = document.createElement('div');
-    inputsWrap.className = 'panel-field__input';
-    const inputs = {};
-    for (const axis of ['x', 'y', 'z']) {
-      const input = document.createElement('input');
-      input.type = 'number';
-      input.step = '0.01';
-      input.disabled = true;
-      input.placeholder = axis.toUpperCase();
-      input.addEventListener('keydown', event => {
-        if (event.key === 'Enter') {
-          event.preventDefault();
-          input.blur();
-        }
-      });
-      input.addEventListener('change', () => {
-        properties.editVectorComponent(prop, axis, input.value);
-      });
-      inputs[axis] = input;
-      inputsWrap.appendChild(input);
-    }
-    field.append(label, inputsWrap);
-    section.appendChild(field);
-    vectorFields[prop] = inputs;
+  const element = properties.getElement();
+  if (element) {
+    container.appendChild(element);
+  } else {
+    const hint = document.createElement('p');
+    hint.className = 'hint';
+    hint.textContent = 'Properties are unavailable in this environment.';
+    container.appendChild(hint);
   }
-
-  nameInput.addEventListener('keydown', event => {
-    if (event.key === 'Enter') {
-      event.preventDefault();
-      nameInput.blur();
-    }
-  });
-  nameInput.addEventListener('change', () => {
-    properties.editName(nameInput.value);
-  });
-
-  const status = document.createElement('div');
-  status.className = 'hint';
-  status.textContent = 'Select an object to edit its properties.';
-  container.appendChild(status);
-
-  properties.onChange(state => {
-    if (!state) {
-      nameInput.disabled = true;
-      nameInput.value = '';
-      nameInput.placeholder = 'No selection';
-      for (const inputs of Object.values(vectorFields)) {
-        for (const input of Object.values(inputs)) {
-          input.disabled = true;
-          input.value = '';
-          input.placeholder = input.placeholder ?? '';
-        }
-      }
-      status.textContent = 'Select an object to edit its properties.';
-      return;
-    }
-
-    nameInput.disabled = false;
-    if (state.Name.mixed) {
-      nameInput.value = '';
-      nameInput.placeholder = 'Multiple values';
-      nameInput.classList.add('is-mixed');
-    } else {
-      nameInput.value = state.Name.value ?? '';
-      nameInput.placeholder = '';
-      nameInput.classList.remove('is-mixed');
-    }
-
-    for (const prop of ['Position', 'Rotation', 'Scale']) {
-      const vector = state[prop];
-      const inputs = vectorFields[prop];
-      for (const axis of ['x', 'y', 'z']) {
-        const input = inputs[axis];
-        input.disabled = false;
-        const value = vector?.value?.[axis];
-        input.value = typeof value === 'number' ? value.toFixed(3) : '';
-        input.classList.toggle('is-mixed', Boolean(vector?.mixed?.[axis]));
-        if (vector?.mixed?.[axis]) {
-          input.placeholder = '—';
-        } else {
-          input.placeholder = axis.toUpperCase();
-        }
-      }
-    }
-
-    const count = selection.get().length;
-    status.textContent = count
-      ? `${count} object${count === 1 ? '' : 's'} selected`
-      : 'Select an object to edit its properties.';
-  });
-
   return container;
 }
 
@@ -306,7 +198,7 @@ export function bootstrap() {
   viewportPane.className = 'viewport-pane';
 
   const explorerPanel = createExplorerPanel(explorer);
-  const propertiesPanel = createPropertiesPanel(properties, selection);
+  const propertiesPanel = createPropertiesPanel(properties);
   const consolePanel = createConsolePanel(consolePane);
   const assetsPanel = createAssetsPanel(assetsPane, shell);
 

--- a/editor/panes/properties.css
+++ b/editor/panes/properties.css
@@ -1,0 +1,361 @@
+.properties-pane {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.5rem 0;
+  min-height: 0;
+}
+
+.properties-pane__status {
+  font-size: 0.75rem;
+  color: rgba(245, 247, 251, 0.6);
+}
+
+.properties-pane__status strong {
+  color: rgba(245, 247, 251, 0.92);
+}
+
+.property-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  min-height: 0;
+}
+
+.property-grid.is-empty {
+  justify-content: center;
+  align-items: center;
+  min-height: 160px;
+}
+
+.property-grid__empty {
+  font-size: 0.9rem;
+  color: rgba(245, 247, 251, 0.6);
+  text-align: center;
+  padding: 1.5rem 1rem;
+}
+
+.property-grid__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.property-grid__section-header {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(245, 247, 251, 0.52);
+  padding: 0 0.4rem;
+}
+
+.property-grid__section-body {
+  display: flex;
+  flex-direction: column;
+  background: rgba(12, 16, 24, 0.8);
+  border-radius: 0.6rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  overflow: hidden;
+}
+
+.property-grid__row {
+  display: grid;
+  grid-template-columns: minmax(160px, 0.9fr) minmax(0, 1fr);
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.4rem 0.75rem;
+  min-height: 24px;
+  transition: background var(--transition-fast), border var(--transition-fast);
+}
+
+.property-grid__row + .property-grid__row {
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.property-grid__row:hover {
+  background: rgba(91, 139, 255, 0.08);
+}
+
+.property-grid__row.is-readonly {
+  opacity: 0.8;
+}
+
+.property-grid__row.is-highlight {
+  background: rgba(91, 139, 255, 0.12);
+}
+
+.property-grid__label {
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: rgba(245, 247, 251, 0.78);
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.property-grid__label-description {
+  font-size: 0.72rem;
+  color: rgba(245, 247, 251, 0.52);
+}
+
+.property-grid__value {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-height: 24px;
+}
+
+.property-grid__actions {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.25rem;
+}
+
+.property-grid__action {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+  color: inherit;
+  border-radius: 0.35rem;
+  padding: 0.15rem 0.5rem;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: background var(--transition-fast), border var(--transition-fast);
+}
+
+.property-grid__action:hover {
+  background: rgba(91, 139, 255, 0.18);
+  border-color: rgba(91, 139, 255, 0.45);
+}
+
+.property-grid__action--primary {
+  background: var(--accent-weak);
+  border-color: rgba(91, 139, 255, 0.55);
+  color: #fff;
+}
+
+.property-grid__action--primary:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.property-grid__help {
+  grid-column: 1 / -1;
+  font-size: 0.7rem;
+  color: rgba(245, 247, 251, 0.52);
+  padding: 0 0.75rem 0.4rem;
+}
+
+.property-editor {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  width: 100%;
+}
+
+.property-editor__field,
+.property-editor__vector-field,
+.property-editor__select,
+.property-editor__slider,
+.property-editor__hex {
+  width: 100%;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.45rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(12, 16, 24, 0.85);
+  color: inherit;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.property-editor__field:focus,
+.property-editor__vector-field:focus,
+.property-editor__select:focus,
+.property-editor__slider:focus,
+.property-editor__hex:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px rgba(91, 139, 255, 0.35);
+}
+
+.property-editor__field[disabled],
+.property-editor__vector-field[disabled],
+.property-editor__select[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.property-editor--vector {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.3rem;
+}
+
+.property-editor__vector-field {
+  text-align: right;
+}
+
+.property-editor__vector-field.is-mixed {
+  font-style: italic;
+}
+
+.property-editor--bool {
+  justify-content: flex-start;
+  gap: 0.4rem;
+}
+
+.property-editor__toggle {
+  position: relative;
+  width: 42px;
+  height: 22px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+  transition: background var(--transition-fast), border var(--transition-fast);
+}
+
+.property-editor__toggle::after {
+  content: '';
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  top: 1px;
+  left: 1px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform var(--transition-fast);
+}
+
+.property-editor__toggle.is-on {
+  background: var(--accent-weak);
+  border-color: var(--accent);
+}
+
+.property-editor__toggle.is-on::after {
+  transform: translateX(20px);
+}
+
+.property-editor__toggle-label {
+  font-size: 0.78rem;
+  color: rgba(245, 247, 251, 0.78);
+}
+
+.property-editor--color {
+  justify-content: flex-start;
+  gap: 0.5rem;
+}
+
+.property-editor__color-swatch {
+  width: 30px;
+  height: 22px;
+  border-radius: 0.35rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(12, 16, 24, 0.85);
+  cursor: pointer;
+  padding: 0;
+}
+
+.property-editor__color-label {
+  font-size: 0.8rem;
+  color: rgba(245, 247, 251, 0.86);
+}
+
+.property-editor__popover {
+  position: absolute;
+  z-index: 999;
+  background: rgba(17, 21, 24, 0.98);
+  border-radius: 0.6rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: var(--shadow-1);
+  padding: 0.75rem;
+}
+
+.property-editor--slider {
+  gap: 0.5rem;
+}
+
+.property-editor__slider {
+  flex: 1 1 auto;
+  accent-color: var(--accent);
+}
+
+.property-editor__slider-value {
+  min-width: 48px;
+  font-size: 0.78rem;
+  text-align: right;
+  color: rgba(245, 247, 251, 0.78);
+}
+
+.property-editor--text .property-editor__field.is-monospace,
+.property-editor__field.is-monospace,
+textarea.is-monospace {
+  font-family: 'JetBrains Mono', 'SFMono-Regular', 'Consolas', monospace;
+}
+
+textarea.property-editor__field {
+  min-height: 58px;
+  resize: vertical;
+}
+
+.colorpicker {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  min-width: 220px;
+}
+
+.colorpicker__sv,
+.colorpicker__hue {
+  position: relative;
+  border-radius: 0.45rem;
+  overflow: hidden;
+}
+
+.colorpicker__sv-canvas,
+.colorpicker__hue-canvas {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: inherit;
+}
+
+.colorpicker__sv-thumb,
+.colorpicker__hue-thumb {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid #fff;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.55);
+  transform: translate(-50%, -50%);
+}
+
+.colorpicker__hue-thumb {
+  top: 50%;
+}
+
+.colorpicker__controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.colorpicker__preview {
+  width: 36px;
+  height: 36px;
+  border-radius: 0.45rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.colorpicker__hex {
+  flex: 1 1 auto;
+  padding: 0.35rem 0.55rem;
+  border-radius: 0.45rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(12, 16, 24, 0.85);
+  color: inherit;
+}
+
+.colorpicker__hex:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px rgba(91, 139, 255, 0.35);
+}

--- a/editor/panes/properties.js
+++ b/editor/panes/properties.js
@@ -1,64 +1,274 @@
 import UndoService from '../services/undo.js';
 import { Selection } from '../services/selection.js';
+import PropertyGrid from '../ui/propgrid/propgrid.js';
+import { isVector3, isColor3, isValidAttribute } from '../../engine/core/types.js';
 
 const VECTOR_PROPS = ['Position', 'Rotation', 'Scale'];
+const MIXED_PLACEHOLDER = '—';
 
-function cloneVector(value = {}) {
-  return {
-    x: typeof value.x === 'number' ? value.x : 0,
-    y: typeof value.y === 'number' ? value.y : 0,
-    z: typeof value.z === 'number' ? value.z : 0,
-  };
-}
+const ATTRIBUTE_TYPES = [
+  { value: 'string', label: 'String' },
+  { value: 'number', label: 'Number' },
+  { value: 'boolean', label: 'Boolean' },
+  { value: 'Vector3', label: 'Vector3' },
+  { value: 'Color3', label: 'Color3' },
+  { value: 'JSON', label: 'JSON' },
+];
 
-function buildVectorField(instances, prop) {
-  const vectors = instances.map(inst => cloneVector(inst[prop]));
-  if (!vectors.length) {
-    return { value: cloneVector(), mixed: { x: false, y: false, z: false } };
-  }
-
-  const base = vectors[0];
-  const mixed = { x: false, y: false, z: false };
-  for (const vec of vectors.slice(1)) {
-    for (const axis of ['x', 'y', 'z']) {
-      if (base[axis] !== vec[axis]) {
-        mixed[axis] = true;
-      }
-    }
-  }
-
-  return { value: { ...base }, mixed };
-}
-
-function buildNameField(instances) {
-  if (!instances.length) return { value: '', mixed: false };
-  const name = instances[0].Name ?? '';
-  const mixed = instances.some(inst => (inst.Name ?? '') !== name);
-  return { value: mixed ? '' : name, mixed };
-}
+const ATTRIBUTE_DEFAULTS = {
+  string: () => '',
+  number: () => 0,
+  boolean: () => false,
+  Vector3: () => ({ x: 0, y: 0, z: 0 }),
+  Color3: () => ({ r: 1, g: 1, b: 1 }),
+  JSON: () => ({}),
+};
 
 function combineCommands(undo, commands) {
-  if (!commands.length) return;
-  if (commands.length === 1) {
-    undo.execute(commands[0]);
+  const valid = commands.filter(Boolean);
+  if (!valid.length) return;
+  if (valid.length === 1) {
+    undo.execute(valid[0]);
     return;
   }
-
   undo.execute({
     undo: () => {
-      for (const cmd of [...commands].reverse()) {
-        cmd.undo();
+      for (const cmd of [...valid].reverse()) {
+        cmd.undo?.();
       }
     },
     redo: () => {
-      for (const cmd of commands) {
-        cmd.redo();
+      for (const cmd of valid) {
+        cmd.redo?.();
       }
     },
   });
 }
 
-// Minimal properties pane. Editing a numeric property pushes an undo entry.
+function cloneVector(value = {}) {
+  return {
+    x: Number.isFinite(value.x) ? value.x : 0,
+    y: Number.isFinite(value.y) ? value.y : 0,
+    z: Number.isFinite(value.z) ? value.z : 0,
+  };
+}
+
+function cloneColor(value = {}) {
+  return {
+    r: Number.isFinite(value.r) ? Math.max(0, Math.min(1, value.r)) : 0,
+    g: Number.isFinite(value.g) ? Math.max(0, Math.min(1, value.g)) : 0,
+    b: Number.isFinite(value.b) ? Math.max(0, Math.min(1, value.b)) : 0,
+  };
+}
+
+function cloneAttributeValue(value) {
+  if (isVector3(value)) return cloneVector(value);
+  if (isColor3(value)) return cloneColor(value);
+  if (value && typeof value === 'object') {
+    try {
+      return JSON.parse(JSON.stringify(value));
+    } catch {
+      // Fallback to shallow clone
+      return { ...value };
+    }
+  }
+  return value;
+}
+
+function valuesEqual(a, b) {
+  if (a === b) return true;
+  if (Number.isNaN(a) && Number.isNaN(b)) return true;
+  if (isVector3(a) && isVector3(b)) {
+    return a.x === b.x && a.y === b.y && a.z === b.z;
+  }
+  if (isColor3(a) && isColor3(b)) {
+    return a.r === b.r && a.g === b.g && a.b === b.b;
+  }
+  if (typeof a === 'object' && typeof b === 'object') {
+    try {
+      return JSON.stringify(a) === JSON.stringify(b);
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+function detectAttributeType(value) {
+  const type = typeof value;
+  if (type === 'string') return 'string';
+  if (type === 'number') return 'number';
+  if (type === 'boolean') return 'boolean';
+  if (isVector3(value)) return 'Vector3';
+  if (isColor3(value)) return 'Color3';
+  if (value === undefined) return 'string';
+  return 'JSON';
+}
+
+function buildScalarField(instances, prop, { accessor = inst => inst[prop], formatter = v => v } = {}) {
+  if (!instances.length) return null;
+  const values = instances.map(inst => accessor(inst));
+  const firstDefined = values.find(v => v !== undefined);
+  if (firstDefined === undefined) {
+    return { value: null, mixed: false };
+  }
+  const mixed = values.some(val => !valuesEqual(val, firstDefined));
+  return {
+    value: mixed ? formatter(firstDefined) : formatter(firstDefined),
+    raw: firstDefined,
+    mixed,
+    values,
+  };
+}
+
+function buildVectorField(instances, prop) {
+  const vectors = instances.map(inst => inst[prop]).filter(value => isVector3(value));
+  if (!vectors.length) return null;
+  const base = cloneVector(vectors[0]);
+  const mixed = { x: false, y: false, z: false };
+  for (const vector of vectors.slice(1)) {
+    if (base.x !== vector.x) mixed.x = true;
+    if (base.y !== vector.y) mixed.y = true;
+    if (base.z !== vector.z) mixed.z = true;
+  }
+  if (vectors.length !== instances.length) {
+    mixed.x = true;
+    mixed.y = true;
+    mixed.z = true;
+  }
+  return { value: base, mixed };
+}
+
+function buildParentField(instances) {
+  if (!instances.length) return null;
+  const parents = instances.map(inst => inst.Parent ?? null);
+  const first = parents.find(parent => parent != null) ?? null;
+  let mixed = false;
+  for (const parent of parents) {
+    if (parent !== first) {
+      mixed = true;
+      break;
+    }
+  }
+  const label = first ? first.Name ?? first.ClassName ?? 'Instance' : 'None';
+  return { parent: first, parents, label, mixed };
+}
+
+function buildVisibleField(instances) {
+  return buildScalarField(instances, 'Visible', {
+    accessor: inst => (inst.Visible === undefined ? true : Boolean(inst.Visible)),
+    formatter: value => Boolean(value),
+  });
+}
+
+function getPrimaryMaterial(inst) {
+  if (!inst) return null;
+  if (typeof inst.getMaterialForPrimitive === 'function') {
+    return inst.getMaterialForPrimitive(0) ?? null;
+  }
+  if (Array.isArray(inst.materials) && inst.materials.length) {
+    return inst.materials[0];
+  }
+  return inst.Material ?? null;
+}
+
+function buildMaterialField(instances) {
+  const materials = instances.map(inst => getPrimaryMaterial(inst));
+  const first = materials.find(mat => mat != null) ?? null;
+  const mixed = materials.some(mat => mat !== first);
+  return { value: first, mixed };
+}
+
+function buildVectorAttribute(values) {
+  const vectors = values.filter(val => isVector3(val));
+  if (!vectors.length) {
+    return { value: { x: 0, y: 0, z: 0 }, mixed: { x: true, y: true, z: true } };
+  }
+  const base = cloneVector(vectors[0]);
+  const mixed = { x: false, y: false, z: false };
+  for (const vec of vectors.slice(1)) {
+    if (base.x !== vec.x) mixed.x = true;
+    if (base.y !== vec.y) mixed.y = true;
+    if (base.z !== vec.z) mixed.z = true;
+  }
+  if (vectors.length !== values.length) {
+    mixed.x = true;
+    mixed.y = true;
+    mixed.z = true;
+  }
+  return { value: base, mixed };
+}
+
+function buildColorAttribute(values) {
+  const colors = values.filter(val => isColor3(val));
+  if (!colors.length) {
+    return { value: { r: 1, g: 1, b: 1 }, mixed: true };
+  }
+  const base = cloneColor(colors[0]);
+  let mixed = false;
+  for (const color of colors.slice(1)) {
+    if (base.r !== color.r || base.g !== color.g || base.b !== color.b) {
+      mixed = true;
+      break;
+    }
+  }
+  if (colors.length !== values.length) mixed = true;
+  return { value: base, mixed };
+}
+
+function buildAttributes(instances) {
+  const keys = new Set();
+  for (const inst of instances) {
+    if (!inst?.Attributes) continue;
+    for (const key of inst.Attributes.keys()) {
+      keys.add(key);
+    }
+  }
+  const result = [];
+  for (const key of keys) {
+    const values = instances.map(inst => inst?.GetAttribute?.(key));
+    const defined = values.filter(value => value !== undefined);
+    const type = detectAttributeType(defined[0]);
+    const entry = { name: key, type, values, mixed: false };
+    if (type === 'Vector3') {
+      const vectorData = buildVectorAttribute(values);
+      entry.value = vectorData.value;
+      entry.mixed = vectorData.mixed;
+    } else if (type === 'Color3') {
+      const colorData = buildColorAttribute(values);
+      entry.value = colorData.value;
+      entry.mixed = colorData.mixed;
+    } else if (type === 'JSON') {
+      const base = defined[0] ?? {};
+      entry.value = JSON.stringify(base, null, 2);
+      entry.mixed = values.some(val => !valuesEqual(val, base));
+    } else {
+      const base = defined[0];
+      entry.value = base;
+      entry.mixed = values.some(val => !valuesEqual(val, base));
+    }
+    entry.presentInAll = values.every(value => value !== undefined);
+    result.push(entry);
+  }
+  result.sort((a, b) => a.name.localeCompare(b.name));
+  return result;
+}
+
+function formatSelectionStatus(count) {
+  if (count <= 0) return 'Select an object to edit its properties.';
+  if (count === 1) return '1 object selected';
+  return `${count} objects selected`;
+}
+
+function ensureArray(value) {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function sanitizeAttributeName(name) {
+  return String(name ?? '').trim();
+}
+
 export default class Properties {
   constructor(undo = new UndoService(), selection = new Selection()) {
     this.undo = undo;
@@ -67,6 +277,22 @@ export default class Properties {
     this.boundConnections = [];
     this.current = null;
     this._listeners = new Set();
+    this.hasDOM = typeof document !== 'undefined' && typeof document.createElement === 'function';
+
+    if (this.hasDOM) {
+      this.element = document.createElement('div');
+      this.element.className = 'properties-pane';
+      this.grid = new PropertyGrid();
+      this.grid.setEmptyMessage('Select an object to edit its properties.');
+      this.element.appendChild(this.grid.getElement());
+      this.statusElement = document.createElement('div');
+      this.statusElement.className = 'properties-pane__status';
+      this.element.appendChild(this.statusElement);
+    } else {
+      this.element = null;
+      this.grid = null;
+      this.statusElement = null;
+    }
 
     this.selectionConnection = this.selection.Changed.Connect(sel => {
       this._bindInstances(sel);
@@ -79,6 +305,11 @@ export default class Properties {
     if (this.selectionConnection) this.selectionConnection.Disconnect();
     this._disconnectBound();
     this._listeners.clear();
+    this.grid?.dispose?.();
+  }
+
+  getElement() {
+    return this.element;
   }
 
   getCurrent() {
@@ -86,9 +317,7 @@ export default class Properties {
   }
 
   onChange(listener) {
-    if (typeof listener !== 'function') {
-      return () => {};
-    }
+    if (typeof listener !== 'function') return () => {};
     this._listeners.add(listener);
     if (this.current) {
       try {
@@ -102,12 +331,6 @@ export default class Properties {
     };
   }
 
-  editNumber(inst, prop, value) {
-    const num = Number(value);
-    if (Number.isNaN(num)) return;
-    this.undo.execute(this.undo.setProperty(inst, prop, num));
-  }
-
   editName(value) {
     const text = String(value ?? '');
     const commands = this.boundInstances.map(inst => this.undo.setProperty(inst, 'Name', text));
@@ -117,55 +340,161 @@ export default class Properties {
   editVectorComponent(prop, axis, value) {
     if (!VECTOR_PROPS.includes(prop)) return;
     const num = Number(value);
-    if (Number.isNaN(num)) return;
-
+    if (!Number.isFinite(num)) return;
     const commands = [];
     for (const inst of this.boundInstances) {
       const current = cloneVector(inst[prop]);
       if (current[axis] === num) continue;
       const next = { ...current, [axis]: num };
-      commands.push({
-        undo: () => inst.setProperty(prop, { ...current }),
-        redo: () => inst.setProperty(prop, { ...next }),
-      });
+      commands.push(this.undo.setProperty(inst, prop, next));
     }
-
     combineCommands(this.undo, commands);
+  }
+
+  editBoolean(prop, value) {
+    const bool = Boolean(value);
+    const commands = this.boundInstances
+      .filter(inst => prop in inst || inst[prop] !== undefined)
+      .map(inst => this.undo.setProperty(inst, prop, bool));
+    combineCommands(this.undo, commands);
+  }
+
+  editAttribute(name, type, value) {
+    const attrName = sanitizeAttributeName(name);
+    if (!attrName) return;
+    let prepared = value;
+    if (type === 'string') {
+      prepared = String(value ?? '');
+    } else if (type === 'number') {
+      const num = Number(value);
+      if (!Number.isFinite(num)) return;
+      prepared = num;
+    } else if (type === 'boolean') {
+      prepared = Boolean(value);
+    } else if (type === 'Color3') {
+      prepared = cloneColor(value);
+    } else if (type === 'JSON') {
+      try {
+        prepared = typeof value === 'string' ? JSON.parse(value) : value;
+      } catch {
+        console.warn('[Properties] Failed to parse JSON attribute', attrName);
+        return;
+      }
+    }
+    if (!isValidAttribute(prepared)) {
+      console.warn('[Properties] Invalid attribute value for', attrName);
+      return;
+    }
+    const commands = this.boundInstances.map(inst => this.undo.setAttribute(inst, attrName, cloneAttributeValue(prepared)));
+    combineCommands(this.undo, commands);
+  }
+
+  editAttributeVectorComponent(name, axis, value) {
+    const attrName = sanitizeAttributeName(name);
+    if (!attrName || !['x', 'y', 'z'].includes(axis)) return;
+    const num = Number(value);
+    if (!Number.isFinite(num)) return;
+    const commands = [];
+    for (const inst of this.boundInstances) {
+      const current = inst.GetAttribute(attrName);
+      const base = isVector3(current) ? cloneVector(current) : { x: 0, y: 0, z: 0 };
+      if (base[axis] === num) continue;
+      const next = { ...base, [axis]: num };
+      commands.push(this.undo.setAttribute(inst, attrName, next));
+    }
+    combineCommands(this.undo, commands);
+  }
+
+  editAttributeColor(name, color) {
+    const attrName = sanitizeAttributeName(name);
+    if (!attrName) return;
+    const prepared = cloneColor(color);
+    const commands = this.boundInstances.map(inst => this.undo.setAttribute(inst, attrName, prepared));
+    combineCommands(this.undo, commands);
+  }
+
+  editAttributeJSON(name, text) {
+    const attrName = sanitizeAttributeName(name);
+    if (!attrName) return;
+    let parsed;
+    try {
+      parsed = typeof text === 'string' ? JSON.parse(text) : text;
+    } catch {
+      console.warn('[Properties] Invalid JSON for attribute', attrName);
+      return;
+    }
+    if (!isValidAttribute(parsed)) {
+      console.warn('[Properties] Invalid attribute value for', attrName);
+      return;
+    }
+    const commands = this.boundInstances.map(inst => this.undo.setAttribute(inst, attrName, cloneAttributeValue(parsed)));
+    combineCommands(this.undo, commands);
+  }
+
+  removeAttribute(name) {
+    const attrName = sanitizeAttributeName(name);
+    if (!attrName) return;
+    const commands = this.boundInstances.map(inst => this.undo.removeAttribute(inst, attrName));
+    combineCommands(this.undo, commands);
+  }
+
+  addAttribute(name, type) {
+    const attrName = sanitizeAttributeName(name);
+    if (!attrName) return false;
+    const factory = ATTRIBUTE_DEFAULTS[type] ?? ATTRIBUTE_DEFAULTS.string;
+    const commands = this.boundInstances.map(inst => this.undo.setAttribute(inst, attrName, factory()));
+    combineCommands(this.undo, commands);
+    return true;
   }
 
   _bindInstances(instances) {
     this._disconnectBound();
-    this.boundInstances = [...instances];
+    this.boundInstances = ensureArray(instances);
     this.current = this._buildState();
+    this._updateView();
     this._emitChange();
 
     for (const inst of this.boundInstances) {
-      this.boundConnections.push(
-        inst.Changed.Connect(prop => {
-          if (prop === 'Name' || VECTOR_PROPS.includes(prop)) {
-            this.current = this._buildState();
-            this._emitChange();
-          }
-        }),
-      );
+      if (!inst?.Changed) continue;
+      const conn = inst.Changed.Connect(() => {
+        this.current = this._buildState();
+        this._updateView();
+        this._emitChange();
+      });
+      this.boundConnections.push(conn);
     }
   }
 
   _disconnectBound() {
     for (const conn of this.boundConnections) {
-      conn.Disconnect();
+      try {
+        conn?.Disconnect?.();
+      } catch (err) {
+        console.warn('[Properties] Failed to disconnect listener', err);
+      }
     }
     this.boundConnections = [];
   }
 
   _buildState() {
     const instances = this.boundInstances;
-    return {
-      Name: buildNameField(instances),
-      Position: buildVectorField(instances, 'Position'),
-      Rotation: buildVectorField(instances, 'Rotation'),
-      Scale: buildVectorField(instances, 'Scale'),
+    if (!instances.length) return null;
+    const state = {
+      instances,
+      count: instances.length,
+      Name: buildScalarField(instances, 'Name', {
+        accessor: inst => inst.Name ?? '',
+        formatter: value => value ?? '',
+      }),
+      Parent: buildParentField(instances),
+      Visible: buildVisibleField(instances),
+      Material: buildMaterialField(instances),
+      Attributes: buildAttributes(instances),
     };
+    for (const prop of VECTOR_PROPS) {
+      state[prop] = buildVectorField(instances, prop);
+    }
+    return state;
   }
 
   _emitChange() {
@@ -176,5 +505,219 @@ export default class Properties {
         console.error('[Properties] onChange listener error', err);
       }
     }
+  }
+
+  _updateView() {
+    if (this.statusElement) {
+      this.statusElement.textContent = formatSelectionStatus(this.current?.count ?? 0);
+    }
+    if (!this.grid) return;
+    if (!this.current) {
+      this.grid.setSections([]);
+      return;
+    }
+    const sections = this._buildSections(this.current);
+    this.grid.setSections(sections);
+  }
+
+  _buildSections(state) {
+    const sections = [];
+
+    const dataRows = [];
+    if (state.Name) {
+      dataRows.push({
+        id: 'prop-name',
+        label: 'Name',
+        type: 'text',
+        value: state.Name.mixed ? '' : state.Name.value,
+        placeholder: state.Name.mixed ? MIXED_PLACEHOLDER : '',
+        mixed: state.Name.mixed,
+        onCommit: value => this.editName(value),
+      });
+    }
+    if (state.Parent) {
+      dataRows.push({
+        id: 'prop-parent',
+        label: 'Parent',
+        type: 'text',
+        value: state.Parent.mixed ? '' : state.Parent.label,
+        placeholder: state.Parent.mixed ? MIXED_PLACEHOLDER : state.Parent.label,
+        readOnly: true,
+        mixed: state.Parent.mixed,
+        actions: state.Parent.mixed || !state.Parent.parent
+          ? []
+          : [{
+              text: 'Select',
+              label: 'Select parent',
+              onClick: () => {
+                if (state.Parent.parent) this.selection.set([state.Parent.parent]);
+              },
+            }],
+      });
+    }
+    if (dataRows.length) {
+      sections.push({ id: 'section-data', label: 'Data', rows: dataRows });
+    }
+
+    const transformRows = [];
+    for (const prop of VECTOR_PROPS) {
+      const vector = state[prop];
+      if (!vector) continue;
+      transformRows.push({
+        id: `prop-${prop.toLowerCase()}`,
+        label: prop,
+        type: 'vector3',
+        value: vector.value,
+        mixed: vector.mixed,
+        options: { precision: 3 },
+        onCommit: ({ axis, value }) => this.editVectorComponent(prop, axis, value),
+      });
+    }
+    if (transformRows.length) {
+      sections.push({ id: 'section-transform', label: 'Transform', rows: transformRows });
+    }
+
+    const appearanceRows = [];
+    if (state.Visible) {
+      appearanceRows.push({
+        id: 'prop-visible',
+        label: 'Visible',
+        type: 'bool',
+        value: Boolean(state.Visible.value),
+        mixed: state.Visible.mixed,
+        onCommit: value => this.editBoolean('Visible', value),
+      });
+    }
+    if (state.Material) {
+      appearanceRows.push({
+        id: 'prop-material',
+        label: 'Material',
+        type: 'text',
+        readOnly: true,
+        value: state.Material.mixed ? '' : state.Material.value ?? 'None',
+        placeholder: state.Material.mixed ? MIXED_PLACEHOLDER : 'None',
+        mixed: state.Material.mixed,
+      });
+    }
+    if (appearanceRows.length) {
+      sections.push({ id: 'section-appearance', label: 'Appearance', rows: appearanceRows });
+    }
+
+    const attributeRows = [];
+    for (const attribute of state.Attributes) {
+      const editorType = this._editorTypeForAttribute(attribute.type);
+      const row = {
+        id: `attr-${attribute.name}`,
+        label: attribute.name,
+        type: editorType,
+        value: attribute.type === 'string'
+          ? (attribute.mixed ? '' : attribute.value ?? '')
+          : attribute.type === 'number'
+            ? (attribute.mixed ? null : attribute.value ?? 0)
+            : attribute.type === 'JSON'
+              ? (attribute.mixed ? '' : attribute.value ?? '')
+              : attribute.value,
+        mixed: attribute.mixed,
+        options: {},
+        actions: [{
+          text: 'Remove',
+          label: 'Remove attribute',
+          onClick: () => this.removeAttribute(attribute.name),
+        }],
+      };
+      if (attribute.type === 'string') {
+        row.placeholder = attribute.mixed ? MIXED_PLACEHOLDER : '';
+        row.onCommit = value => this.editAttribute(attribute.name, 'string', value);
+      } else if (attribute.type === 'number') {
+        row.placeholder = attribute.mixed ? MIXED_PLACEHOLDER : '';
+        row.onCommit = value => this.editAttribute(attribute.name, 'number', value);
+      } else if (attribute.type === 'boolean') {
+        row.onCommit = value => this.editAttribute(attribute.name, 'boolean', value);
+      } else if (attribute.type === 'Vector3') {
+        row.onCommit = ({ axis, value }) => this.editAttributeVectorComponent(attribute.name, axis, value);
+        row.options = { precision: 3 };
+      } else if (attribute.type === 'Color3') {
+        row.onCommit = value => this.editAttributeColor(attribute.name, value);
+      } else if (attribute.type === 'JSON') {
+        row.type = 'text';
+        row.options = { multiline: true, monospace: true };
+        row.onCommit = value => this.editAttributeJSON(attribute.name, value);
+        row.placeholder = attribute.mixed ? MIXED_PLACEHOLDER : '';
+      } else {
+        row.onCommit = value => this.editAttribute(attribute.name, attribute.type, value);
+      }
+      attributeRows.push(row);
+    }
+
+    attributeRows.push({
+      id: 'attr-add',
+      label: 'Add Attribute',
+      type: 'custom',
+      options: {
+        render: element => this._renderAttributeCreator(element),
+      },
+    });
+
+    sections.push({ id: 'section-attributes', label: 'Attributes', rows: attributeRows });
+
+    return sections;
+  }
+
+  _editorTypeForAttribute(type) {
+    if (type === 'Vector3') return 'vector3';
+    if (type === 'Color3') return 'color3';
+    if (type === 'boolean') return 'bool';
+    if (type === 'number') return 'number';
+    return 'text';
+  }
+
+  _renderAttributeCreator(container) {
+    container.classList.add('property-editor--add-attribute');
+    const nameInput = document.createElement('input');
+    nameInput.type = 'text';
+    nameInput.className = 'property-editor__field';
+    nameInput.placeholder = 'Attribute Name';
+
+    const typeSelect = document.createElement('select');
+    typeSelect.className = 'property-editor__select';
+    for (const option of ATTRIBUTE_TYPES) {
+      const element = document.createElement('option');
+      element.value = option.value;
+      element.textContent = option.label;
+      typeSelect.appendChild(element);
+    }
+
+    const addButton = document.createElement('button');
+    addButton.type = 'button';
+    addButton.className = 'property-grid__action property-grid__action--primary';
+    addButton.textContent = 'Add';
+
+    const resetInputs = () => {
+      nameInput.value = '';
+      typeSelect.value = ATTRIBUTE_TYPES[0].value;
+      nameInput.focus();
+    };
+
+    const submit = () => {
+      const added = this.addAttribute(nameInput.value, typeSelect.value);
+      if (added) {
+        resetInputs();
+      }
+    };
+
+    addButton.addEventListener('click', submit);
+    nameInput.addEventListener('keydown', event => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        submit();
+      }
+    });
+
+    container.append(nameInput, typeSelect, addButton);
+    return {
+      dispose() {
+        // no-op
+      },
+    };
   }
 }

--- a/editor/services/undo.js
+++ b/editor/services/undo.js
@@ -90,4 +90,28 @@ export default class UndoService {
       },
     };
   }
+
+  removeAttribute(inst, attr) {
+    const hadValue = inst.Attributes.has(attr);
+    const oldValue = inst.GetAttribute(attr);
+    return {
+      undo() {
+        if (hadValue) {
+          inst.SetAttribute(attr, oldValue);
+        } else if (inst.Attributes.has(attr)) {
+          inst.Attributes.delete(attr);
+          if (inst?.Changed?.Fire) inst.Changed.Fire(attr);
+        } else if (inst?.Changed?.Fire) {
+          inst.Changed.Fire(attr);
+        }
+      },
+      redo() {
+        if (inst.Attributes.delete(attr) && inst?.Changed?.Fire) {
+          inst.Changed.Fire(attr);
+        } else if (inst?.Changed?.Fire) {
+          inst.Changed.Fire(attr);
+        }
+      },
+    };
+  }
 }

--- a/editor/ui/colorpicker.js
+++ b/editor/ui/colorpicker.js
@@ -1,0 +1,323 @@
+const SV_SIZE = { width: 180, height: 140 };
+const HUE_SIZE = { width: 180, height: 16 };
+
+function clamp01(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return 0;
+  if (num <= 0) return 0;
+  if (num >= 1) return 1;
+  return num;
+}
+
+function hsvToRgb(h, s, v) {
+  const hh = ((h % 1) + 1) % 1;
+  const ss = clamp01(s);
+  const vv = clamp01(v);
+  const i = Math.floor(hh * 6);
+  const f = hh * 6 - i;
+  const p = vv * (1 - ss);
+  const q = vv * (1 - f * ss);
+  const t = vv * (1 - (1 - f) * ss);
+  switch (i % 6) {
+    case 0: return { r: vv, g: t, b: p };
+    case 1: return { r: q, g: vv, b: p };
+    case 2: return { r: p, g: vv, b: t };
+    case 3: return { r: p, g: q, b: vv };
+    case 4: return { r: t, g: p, b: vv };
+    case 5:
+    default:
+      return { r: vv, g: p, b: q };
+  }
+}
+
+function rgbToHsv(r, g, b) {
+  const rr = clamp01(r);
+  const gg = clamp01(g);
+  const bb = clamp01(b);
+  const max = Math.max(rr, gg, bb);
+  const min = Math.min(rr, gg, bb);
+  const delta = max - min;
+  let h = 0;
+  if (delta !== 0) {
+    if (max === rr) {
+      h = (gg - bb) / delta + (gg < bb ? 6 : 0);
+    } else if (max === gg) {
+      h = (bb - rr) / delta + 2;
+    } else {
+      h = (rr - gg) / delta + 4;
+    }
+    h /= 6;
+  }
+  const s = max === 0 ? 0 : delta / max;
+  return { h, s, v: max };
+}
+
+function componentToHex(value) {
+  const num = Math.round(clamp01(value) * 255);
+  const hex = num.toString(16).padStart(2, '0');
+  return hex.toUpperCase();
+}
+
+function rgbToHex({ r, g, b }) {
+  return `#${componentToHex(r)}${componentToHex(g)}${componentToHex(b)}`;
+}
+
+function hexToRgb(hex) {
+  if (typeof hex !== 'string') return null;
+  let value = hex.trim();
+  if (!value) return null;
+  if (value.startsWith('#')) value = value.slice(1);
+  if (value.length === 3) {
+    value = value.split('').map(ch => ch + ch).join('');
+  }
+  if (value.length !== 6 || /[^0-9a-fA-F]/.test(value)) {
+    return null;
+  }
+  const r = parseInt(value.slice(0, 2), 16) / 255;
+  const g = parseInt(value.slice(2, 4), 16) / 255;
+  const b = parseInt(value.slice(4, 6), 16) / 255;
+  return { r, g, b };
+}
+
+function setCanvasSize(canvas, width, height) {
+  canvas.width = width;
+  canvas.height = height;
+  canvas.style.width = `${width}px`;
+  canvas.style.height = `${height}px`;
+}
+
+class ColorPicker {
+  constructor({ color = { r: 1, g: 1, b: 1 }, onChange = null } = {}) {
+    this._onChange = typeof onChange === 'function' ? onChange : null;
+    this._hsv = { h: 0, s: 0, v: 1 };
+    this._rgb = { r: 1, g: 1, b: 1 };
+
+    this.element = document.createElement('div');
+    this.element.className = 'colorpicker';
+
+    this.svContainer = document.createElement('div');
+    this.svContainer.className = 'colorpicker__sv';
+    this.svCanvas = document.createElement('canvas');
+    this.svCanvas.className = 'colorpicker__sv-canvas';
+    setCanvasSize(this.svCanvas, SV_SIZE.width, SV_SIZE.height);
+    this.svThumb = document.createElement('div');
+    this.svThumb.className = 'colorpicker__sv-thumb';
+    this.svContainer.append(this.svCanvas, this.svThumb);
+
+    this.hueContainer = document.createElement('div');
+    this.hueContainer.className = 'colorpicker__hue';
+    this.hueCanvas = document.createElement('canvas');
+    this.hueCanvas.className = 'colorpicker__hue-canvas';
+    setCanvasSize(this.hueCanvas, HUE_SIZE.width, HUE_SIZE.height);
+    this.hueThumb = document.createElement('div');
+    this.hueThumb.className = 'colorpicker__hue-thumb';
+    this.hueContainer.append(this.hueCanvas, this.hueThumb);
+
+    this.preview = document.createElement('div');
+    this.preview.className = 'colorpicker__preview';
+
+    this.hexInput = document.createElement('input');
+    this.hexInput.className = 'colorpicker__hex';
+    this.hexInput.type = 'text';
+    this.hexInput.placeholder = '#FFFFFF';
+    this.hexInput.maxLength = 7;
+    this.hexInput.autocomplete = 'off';
+    this.hexInput.spellcheck = false;
+
+    const controls = document.createElement('div');
+    controls.className = 'colorpicker__controls';
+    controls.append(this.preview, this.hexInput);
+
+    this.element.append(this.svContainer, this.hueContainer, controls);
+
+    this._renderHueCanvas();
+    this.setColor(color, { silent: true });
+    this._render();
+
+    this._bindEvents();
+  }
+
+  getElement() {
+    return this.element;
+  }
+
+  getColor() {
+    return { ...this._rgb };
+  }
+
+  setColor(color, { silent = false } = {}) {
+    if (!color) return;
+    const next = {
+      r: clamp01(color.r ?? 0),
+      g: clamp01(color.g ?? 0),
+      b: clamp01(color.b ?? 0),
+    };
+    this._rgb = next;
+    this._hsv = rgbToHsv(next.r, next.g, next.b);
+    this._render();
+    if (!silent) {
+      this._emit();
+    }
+  }
+
+  setOnChange(handler) {
+    this._onChange = typeof handler === 'function' ? handler : null;
+  }
+
+  dispose() {
+    // Event listeners rely on DOM removal; ensure references cleared.
+    this._onChange = null;
+  }
+
+  _bindEvents() {
+    this.svCanvas.addEventListener('pointerdown', event => {
+      event.preventDefault();
+      try {
+        this.svCanvas.setPointerCapture(event.pointerId);
+      } catch {}
+      this._handleSVPointer(event);
+      const move = e => this._handleSVPointer(e);
+      const up = () => {
+        try {
+          this.svCanvas.releasePointerCapture(event.pointerId);
+        } catch {}
+        this.svCanvas.removeEventListener('pointermove', move);
+        this.svCanvas.removeEventListener('pointerup', up);
+        this.svCanvas.removeEventListener('pointercancel', up);
+      };
+      this.svCanvas.addEventListener('pointermove', move);
+      this.svCanvas.addEventListener('pointerup', up);
+      this.svCanvas.addEventListener('pointercancel', up);
+    });
+
+    this.hueCanvas.addEventListener('pointerdown', event => {
+      event.preventDefault();
+      try {
+        this.hueCanvas.setPointerCapture(event.pointerId);
+      } catch {}
+      this._handleHuePointer(event);
+      const move = e => this._handleHuePointer(e);
+      const up = () => {
+        try {
+          this.hueCanvas.releasePointerCapture(event.pointerId);
+        } catch {}
+        this.hueCanvas.removeEventListener('pointermove', move);
+        this.hueCanvas.removeEventListener('pointerup', up);
+        this.hueCanvas.removeEventListener('pointercancel', up);
+      };
+      this.hueCanvas.addEventListener('pointermove', move);
+      this.hueCanvas.addEventListener('pointerup', up);
+      this.hueCanvas.addEventListener('pointercancel', up);
+    });
+
+    this.hexInput.addEventListener('keydown', event => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        this._commitHex();
+      }
+    });
+    this.hexInput.addEventListener('blur', () => this._commitHex());
+  }
+
+  _commitHex() {
+    const value = this.hexInput.value.trim();
+    const rgb = hexToRgb(value);
+    if (!rgb) {
+      this.hexInput.value = rgbToHex(this._rgb);
+      return;
+    }
+    this._rgb = {
+      r: clamp01(rgb.r),
+      g: clamp01(rgb.g),
+      b: clamp01(rgb.b),
+    };
+    this._hsv = rgbToHsv(this._rgb.r, this._rgb.g, this._rgb.b);
+    this._render();
+    this._emit();
+  }
+
+  _emit() {
+    if (this._onChange) {
+      this._onChange(this.getColor());
+    }
+  }
+
+  _handleSVPointer(event) {
+    const rect = this.svCanvas.getBoundingClientRect();
+    const x = clamp01((event.clientX - rect.left) / rect.width);
+    const y = clamp01((event.clientY - rect.top) / rect.height);
+    this._hsv.s = x;
+    this._hsv.v = 1 - y;
+    this._rgb = hsvToRgb(this._hsv.h, this._hsv.s, this._hsv.v);
+    this._render(false);
+    this._emit();
+  }
+
+  _handleHuePointer(event) {
+    const rect = this.hueCanvas.getBoundingClientRect();
+    const x = clamp01((event.clientX - rect.left) / rect.width);
+    this._hsv.h = x;
+    this._rgb = hsvToRgb(this._hsv.h, this._hsv.s, this._hsv.v);
+    this._render();
+    this._emit();
+  }
+
+  _render(shouldUpdateCanvas = true) {
+    if (shouldUpdateCanvas) {
+      this._renderSVCanvas();
+    }
+    this._updateThumbs();
+    const hex = rgbToHex(this._rgb);
+    this.preview.style.backgroundColor = hex;
+    if (document.activeElement !== this.hexInput) {
+      this.hexInput.value = hex;
+    }
+  }
+
+  _renderHueCanvas() {
+    const ctx = this.hueCanvas.getContext('2d', { alpha: false });
+    const { width, height } = this.hueCanvas;
+    const gradient = ctx.createLinearGradient(0, 0, width, 0);
+    const stops = [
+      { stop: 0, color: '#FF0000' },
+      { stop: 1 / 6, color: '#FFFF00' },
+      { stop: 2 / 6, color: '#00FF00' },
+      { stop: 3 / 6, color: '#00FFFF' },
+      { stop: 4 / 6, color: '#0000FF' },
+      { stop: 5 / 6, color: '#FF00FF' },
+      { stop: 1, color: '#FF0000' },
+    ];
+    for (const entry of stops) {
+      gradient.addColorStop(entry.stop, entry.color);
+    }
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, width, height);
+  }
+
+  _renderSVCanvas() {
+    const ctx = this.svCanvas.getContext('2d', { alpha: false });
+    const { width, height } = this.svCanvas;
+    const hueColor = hsvToRgb(this._hsv.h, 1, 1);
+    const gradientX = ctx.createLinearGradient(0, 0, width, 0);
+    gradientX.addColorStop(0, '#FFFFFF');
+    gradientX.addColorStop(1, rgbToHex(hueColor));
+    ctx.fillStyle = gradientX;
+    ctx.fillRect(0, 0, width, height);
+
+    const gradientY = ctx.createLinearGradient(0, 0, 0, height);
+    gradientY.addColorStop(0, 'rgba(0, 0, 0, 0)');
+    gradientY.addColorStop(1, 'rgba(0, 0, 0, 1)');
+    ctx.fillStyle = gradientY;
+    ctx.fillRect(0, 0, width, height);
+  }
+
+  _updateThumbs() {
+    const { s, v, h } = this._hsv;
+    this.svThumb.style.left = `${s * 100}%`;
+    this.svThumb.style.top = `${(1 - v) * 100}%`;
+    this.hueThumb.style.left = `${h * 100}%`;
+  }
+}
+
+export { rgbToHex, hexToRgb, hsvToRgb, rgbToHsv };
+export default ColorPicker;

--- a/editor/ui/propgrid/propeditors.js
+++ b/editor/ui/propgrid/propeditors.js
@@ -1,0 +1,565 @@
+import ColorPicker, { rgbToHex } from '../colorpicker.js';
+
+const registry = new Map();
+const MIXED_PLACEHOLDER = '—';
+
+function noop() {}
+
+function createWrapper(className) {
+  const wrapper = document.createElement('div');
+  wrapper.className = `property-editor ${className}`.trim();
+  return wrapper;
+}
+
+function setMixedState(element, mixed) {
+  element.classList.toggle('is-mixed', Boolean(mixed));
+}
+
+function formatNumber(value, { precision } = {}) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return '';
+  if (typeof precision === 'number') {
+    return value.toFixed(precision);
+  }
+  return value.toString();
+}
+
+function parseNumber(value, fallback = null) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return fallback;
+  return num;
+}
+
+function createTextEditor(config) {
+  const { value = '', readOnly = false, placeholder = '', mixed = false, onCommit = noop, options = {} } = config;
+  const wrapper = createWrapper('property-editor--text');
+  const input = options.multiline ? document.createElement('textarea') : document.createElement('input');
+  if (!options.multiline) {
+    input.type = options.type ?? 'text';
+  }
+  input.className = 'property-editor__field';
+  input.value = value ?? '';
+  input.placeholder = placeholder ?? '';
+  input.disabled = Boolean(readOnly);
+  if (options.maxLength) input.maxLength = options.maxLength;
+  if (options.minLength) input.minLength = options.minLength;
+  if (options.monospace) input.classList.add('is-monospace');
+  if (options.inputMode) input.inputMode = options.inputMode;
+
+  const commit = () => {
+    if (readOnly) return;
+    onCommit(input.value);
+  };
+
+  input.addEventListener('change', commit);
+  input.addEventListener('blur', commit);
+  input.addEventListener('keydown', event => {
+    if (!options.multiline && event.key === 'Enter') {
+      event.preventDefault();
+      input.blur();
+    }
+    if (options.multiline && event.key === 'Enter' && event.metaKey) {
+      commit();
+    }
+  });
+
+  wrapper.appendChild(input);
+  setMixedState(wrapper, mixed);
+
+  return {
+    element: wrapper,
+    setValue(newValue) {
+      if (document.activeElement === input) return;
+      input.value = newValue ?? '';
+    },
+    setMixed(flag) {
+      setMixedState(wrapper, flag);
+      if (flag) {
+        input.placeholder = '—';
+        if (!readOnly) input.value = '';
+      } else {
+        input.placeholder = placeholder ?? '';
+      }
+    },
+    focus() {
+      input.focus();
+      if (!options.multiline) input.select();
+    },
+    dispose: noop,
+  };
+}
+
+function createNumberEditor(config) {
+  const { value = null, readOnly = false, placeholder = '', mixed = false, onCommit = noop, onInput = null, options = {} } = config;
+  const wrapper = createWrapper('property-editor--number');
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.step = options.step ?? '0.01';
+  if (options.min != null) input.min = options.min;
+  if (options.max != null) input.max = options.max;
+  input.className = 'property-editor__field';
+  input.disabled = Boolean(readOnly);
+  input.placeholder = placeholder ?? '';
+  if (value != null) {
+    input.value = formatNumber(value, options);
+  }
+
+  const emit = handler => {
+    if (!handler) return;
+    const num = parseNumber(input.value, null);
+    if (num == null) return;
+    handler(num);
+  };
+
+  input.addEventListener('change', () => emit(onCommit));
+  input.addEventListener('input', () => emit(onInput));
+  input.addEventListener('keydown', event => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      input.blur();
+    }
+  });
+  input.addEventListener('blur', () => emit(onCommit));
+
+  wrapper.appendChild(input);
+  setMixedState(wrapper, mixed);
+
+  return {
+    element: wrapper,
+    setValue(newValue) {
+      if (document.activeElement === input) return;
+      if (newValue == null) {
+        input.value = '';
+      } else {
+        input.value = formatNumber(newValue, options);
+      }
+    },
+    setMixed(flag) {
+      setMixedState(wrapper, flag);
+      if (flag) {
+        input.placeholder = '—';
+        if (!readOnly) input.value = '';
+      } else {
+        input.placeholder = placeholder ?? '';
+      }
+    },
+    focus() {
+      input.focus();
+      input.select();
+    },
+    dispose: noop,
+  };
+}
+
+function createBoolEditor(config) {
+  const { value = false, readOnly = false, onCommit = noop, onInput = null, mixed = false } = config;
+  const wrapper = createWrapper('property-editor--bool');
+  const toggle = document.createElement('button');
+  toggle.type = 'button';
+  toggle.className = 'property-editor__toggle';
+  const label = document.createElement('span');
+  label.className = 'property-editor__toggle-label';
+  wrapper.append(toggle, label);
+
+  let isMixed = Boolean(mixed);
+  let currentValue = Boolean(value);
+
+  const update = val => {
+    currentValue = Boolean(val);
+    toggle.classList.toggle('is-on', currentValue);
+    label.textContent = currentValue ? 'On' : 'Off';
+    isMixed = false;
+  };
+  update(Boolean(value));
+
+  const emit = val => {
+    if (readOnly) return;
+    update(val);
+    if (onInput) onInput(val);
+    onCommit(val);
+  };
+
+  toggle.addEventListener('click', () => {
+    const next = isMixed ? true : !toggle.classList.contains('is-on');
+    isMixed = false;
+    emit(next);
+  });
+
+  return {
+    element: wrapper,
+    setValue(val) {
+      update(Boolean(val));
+    },
+    setMixed(flag) {
+      setMixedState(wrapper, flag);
+      isMixed = Boolean(flag);
+      if (flag) {
+        toggle.classList.remove('is-on');
+        label.textContent = MIXED_PLACEHOLDER;
+      } else {
+        update(currentValue);
+      }
+    },
+    focus() {
+      toggle.focus();
+    },
+    dispose: noop,
+  };
+}
+
+function createSelectEditor(config) {
+  const { value = null, readOnly = false, placeholder = '', mixed = false, onCommit = noop, options = {} } = config;
+  const wrapper = createWrapper('property-editor--select');
+  const select = document.createElement('select');
+  select.className = 'property-editor__select';
+  select.disabled = Boolean(readOnly);
+
+  if (placeholder) {
+    const option = document.createElement('option');
+    option.value = '';
+    option.textContent = placeholder;
+    select.appendChild(option);
+  }
+
+  const choices = Array.isArray(options.choices) ? options.choices : [];
+  for (const choice of choices) {
+    const option = document.createElement('option');
+    option.value = choice.value;
+    option.textContent = choice.label ?? String(choice.value ?? '');
+    select.appendChild(option);
+  }
+  if (value != null) {
+    select.value = value;
+  } else if (placeholder) {
+    select.value = '';
+  }
+
+  select.addEventListener('change', () => {
+    onCommit(select.value);
+  });
+
+  wrapper.appendChild(select);
+  setMixedState(wrapper, mixed);
+
+  return {
+    element: wrapper,
+    setValue(newValue) {
+      select.value = newValue ?? '';
+    },
+    setMixed(flag) {
+      setMixedState(wrapper, flag);
+      if (flag && placeholder) {
+        select.value = '';
+      }
+    },
+    focus() {
+      select.focus();
+    },
+    dispose: noop,
+  };
+}
+
+function createSliderEditor(config) {
+  const { value = 0, readOnly = false, onCommit = noop, onInput = null, options = {} } = config;
+  const wrapper = createWrapper('property-editor--slider');
+  const slider = document.createElement('input');
+  slider.type = 'range';
+  slider.min = options.min ?? 0;
+  slider.max = options.max ?? 1;
+  slider.step = options.step ?? 0.01;
+  slider.value = value ?? slider.min;
+  slider.disabled = Boolean(readOnly);
+  slider.className = 'property-editor__slider';
+
+  const readout = document.createElement('span');
+  readout.className = 'property-editor__slider-value';
+  readout.textContent = formatNumber(Number(slider.value), options);
+
+  const emitInput = handler => {
+    if (!handler) return;
+    const num = parseNumber(slider.value, null);
+    if (num == null) return;
+    handler(num);
+  };
+
+  slider.addEventListener('input', () => {
+    readout.textContent = formatNumber(Number(slider.value), options);
+    emitInput(onInput);
+  });
+  slider.addEventListener('change', () => {
+    readout.textContent = formatNumber(Number(slider.value), options);
+    emitInput(onCommit);
+  });
+
+  wrapper.append(slider, readout);
+
+  return {
+    element: wrapper,
+    setValue(newValue) {
+      if (newValue == null) return;
+      slider.value = newValue;
+      readout.textContent = formatNumber(Number(slider.value), options);
+    },
+    setMixed(flag) {
+      setMixedState(wrapper, flag);
+    },
+    focus() {
+      slider.focus();
+    },
+    dispose: noop,
+  };
+}
+
+function sanitizeColor(value) {
+  if (!value || typeof value !== 'object') {
+    return { r: 1, g: 1, b: 1 };
+  }
+  return {
+    r: typeof value.r === 'number' ? Math.min(Math.max(value.r, 0), 1) : 0,
+    g: typeof value.g === 'number' ? Math.min(Math.max(value.g, 0), 1) : 0,
+    b: typeof value.b === 'number' ? Math.min(Math.max(value.b, 0), 1) : 0,
+  };
+}
+
+function createColorEditor(config) {
+  const { value = { r: 1, g: 1, b: 1 }, readOnly = false, mixed = false, onCommit = noop, onInput = null } = config;
+  const wrapper = createWrapper('property-editor--color');
+  const swatch = document.createElement('button');
+  swatch.type = 'button';
+  swatch.className = 'property-editor__color-swatch';
+  swatch.disabled = Boolean(readOnly);
+  const label = document.createElement('span');
+  label.className = 'property-editor__color-label';
+  wrapper.append(swatch, label);
+
+  let current = sanitizeColor(value);
+  let picker = null;
+  let popover = null;
+
+  const updateDisplay = color => {
+    const hex = rgbToHex(color);
+    swatch.style.backgroundColor = hex;
+    label.textContent = hex;
+  };
+
+  const closePopover = commit => {
+    if (!popover) return;
+    popover.remove();
+    popover = null;
+    picker?.dispose();
+    picker = null;
+    window.removeEventListener('mousedown', handleWindowDown, true);
+    window.removeEventListener('resize', positionPopover);
+    window.removeEventListener('keydown', handleKey);
+    if (commit) {
+      onCommit(current);
+    }
+  };
+
+  const handleChange = color => {
+    current = sanitizeColor(color);
+    updateDisplay(current);
+    if (onInput) onInput(current);
+  };
+
+  const positionPopover = () => {
+    if (!popover) return;
+    const rect = swatch.getBoundingClientRect();
+    popover.style.top = `${rect.bottom + window.scrollY + 6}px`;
+    popover.style.left = `${rect.left + window.scrollX}px`;
+  };
+
+  const handleWindowDown = event => {
+    if (!popover) return;
+    if (popover.contains(event.target) || swatch.contains(event.target)) {
+      return;
+    }
+    closePopover(true);
+  };
+
+  const handleKey = event => {
+    if (event.key === 'Escape') {
+      closePopover(false);
+    }
+  };
+
+  const openPopover = () => {
+    if (readOnly || popover) return;
+    popover = document.createElement('div');
+    popover.className = 'property-editor__popover';
+    picker = new ColorPicker({ color: current, onChange: handleChange });
+    popover.appendChild(picker.getElement());
+    document.body.appendChild(popover);
+    positionPopover();
+    window.addEventListener('mousedown', handleWindowDown, true);
+    window.addEventListener('resize', positionPopover);
+    window.addEventListener('keydown', handleKey);
+  };
+
+  swatch.addEventListener('click', () => {
+    if (popover) {
+      closePopover(true);
+    } else {
+      openPopover();
+    }
+  });
+
+  updateDisplay(current);
+  setMixedState(wrapper, mixed);
+
+  return {
+    element: wrapper,
+    setValue(color) {
+      current = sanitizeColor(color);
+      updateDisplay(current);
+    },
+    setMixed(flag) {
+      setMixedState(wrapper, flag);
+      if (flag) {
+        label.textContent = '—';
+        swatch.style.backgroundColor = 'transparent';
+      } else {
+        updateDisplay(current);
+      }
+    },
+    focus() {
+      swatch.focus();
+    },
+    dispose() {
+      closePopover(false);
+    },
+  };
+}
+
+function createVectorEditor(config) {
+  const { value = { x: 0, y: 0, z: 0 }, mixed = null, readOnly = false, onCommit = noop, onInput = null, options = {} } = config;
+  const wrapper = createWrapper('property-editor--vector');
+  const axes = ['x', 'y', 'z'];
+  const inputs = new Map();
+
+  const createField = axis => {
+    const field = document.createElement('input');
+    field.type = 'number';
+    field.step = options.step ?? '0.01';
+    if (options.min != null) field.min = options.min;
+    if (options.max != null) field.max = options.max;
+    field.placeholder = axis.toUpperCase();
+    field.disabled = Boolean(readOnly);
+    field.dataset.axis = axis;
+    field.className = 'property-editor__vector-field';
+    if (value && typeof value[axis] === 'number') {
+      field.value = formatNumber(value[axis], options);
+    }
+    const emit = handler => {
+      if (!handler) return;
+      const num = parseNumber(field.value, null);
+      if (num == null) return;
+      handler({ axis, value: num });
+    };
+    field.addEventListener('change', () => emit(onCommit));
+    field.addEventListener('input', () => emit(onInput));
+    field.addEventListener('keydown', event => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        field.blur();
+      }
+    });
+    field.addEventListener('blur', () => emit(onCommit));
+    inputs.set(axis, field);
+    return field;
+  };
+
+  for (const axis of axes) {
+    const field = createField(axis);
+    wrapper.appendChild(field);
+  }
+
+  const updateMixed = state => {
+    if (!state) {
+      for (const [axis, input] of inputs.entries()) {
+        input.classList.remove('is-mixed');
+        input.placeholder = axis.toUpperCase();
+      }
+      return;
+    }
+    for (const [axis, input] of inputs.entries()) {
+      const flag = Boolean(state[axis]);
+      input.classList.toggle('is-mixed', flag);
+      input.placeholder = flag ? '—' : axis.toUpperCase();
+      if (flag && !readOnly) {
+        input.value = '';
+      }
+    }
+  };
+
+  updateMixed(mixed);
+
+  return {
+    element: wrapper,
+    setValue(newValue) {
+      if (!newValue || typeof newValue !== 'object') return;
+      for (const [axis, input] of inputs.entries()) {
+        if (document.activeElement === input) continue;
+        const val = newValue[axis];
+        input.value = typeof val === 'number' ? formatNumber(val, options) : '';
+      }
+    },
+    setMixed(state) {
+      updateMixed(state);
+    },
+    focus() {
+      inputs.get('x')?.focus();
+      inputs.get('x')?.select();
+    },
+    dispose: noop,
+  };
+}
+
+function createDropdownEditor(config) {
+  return createSelectEditor(config);
+}
+
+function createCustomEditor(config) {
+  const wrapper = createWrapper('property-editor--custom');
+  const render = config?.options?.render;
+  let controls = null;
+  if (typeof render === 'function') {
+    controls = render(wrapper, config) || null;
+  }
+  const api = controls || {};
+  return {
+    element: wrapper,
+    setValue: api.setValue || noop,
+    setMixed: api.setMixed || noop,
+    focus: api.focus || noop,
+    dispose: api.dispose || noop,
+  };
+}
+
+function registerDefaults() {
+  if (registry.size > 0) return;
+  registerEditor('text', createTextEditor);
+  registerEditor('number', createNumberEditor);
+  registerEditor('bool', createBoolEditor);
+  registerEditor('enum', createSelectEditor);
+  registerEditor('dropdown', createDropdownEditor);
+  registerEditor('slider', createSliderEditor);
+  registerEditor('vector3', createVectorEditor);
+  registerEditor('color3', createColorEditor);
+  registerEditor('custom', createCustomEditor);
+}
+
+function registerEditor(type, factory) {
+  if (!type || typeof factory !== 'function') return;
+  registry.set(type, factory);
+}
+
+function createEditor(type, config = {}) {
+  registerDefaults();
+  const factory = registry.get(type);
+  if (!factory) {
+    throw new Error(`No property editor registered for type "${type}"`);
+  }
+  return factory(config);
+}
+
+export { registerEditor, createEditor };

--- a/editor/ui/propgrid/propgrid.js
+++ b/editor/ui/propgrid/propgrid.js
@@ -1,0 +1,199 @@
+import { createEditor } from './propeditors.js';
+
+const noop = () => {};
+
+function normalizeSections(sections) {
+  if (!Array.isArray(sections)) return [];
+  return sections.map(section => ({
+    id: section.id ?? Math.random().toString(36).slice(2),
+    label: section.label ?? null,
+    rows: Array.isArray(section.rows) ? section.rows : [],
+    expanded: section.expanded !== false,
+  }));
+}
+
+export default class PropertyGrid {
+  constructor(parent = null) {
+    this.element = document.createElement('div');
+    this.element.className = 'property-grid';
+    this._sections = [];
+    this._message = '';
+    this._messageElement = document.createElement('div');
+    this._messageElement.className = 'property-grid__empty';
+    this._activeEditors = [];
+
+    if (parent) {
+      parent.appendChild(this.element);
+    }
+  }
+
+  getElement() {
+    return this.element;
+  }
+
+  setEmptyMessage(message) {
+    this._message = message ?? '';
+    this._messageElement.textContent = this._message;
+  }
+
+  setSections(sections) {
+    this._sections = normalizeSections(sections);
+    this._render();
+  }
+
+  dispose() {
+    this._disposeEditors();
+    this.element.textContent = '';
+  }
+
+  _disposeEditors() {
+    for (const editor of this._activeEditors) {
+      try {
+        editor?.dispose?.();
+      } catch (err) {
+        console.warn('PropertyGrid editor dispose failed', err);
+      }
+    }
+    this._activeEditors = [];
+  }
+
+  _render() {
+    this._disposeEditors();
+    this.element.textContent = '';
+    const visibleSections = this._sections
+      .map(section => ({ ...section, rows: section.rows.filter(row => row && row.visible !== false) }))
+      .filter(section => section.rows.length > 0);
+
+    if (!visibleSections.length) {
+      if (this._message) {
+        this._messageElement.textContent = this._message;
+        this.element.appendChild(this._messageElement);
+      }
+      this.element.classList.add('is-empty');
+      return;
+    }
+
+    this.element.classList.remove('is-empty');
+
+    for (const section of visibleSections) {
+      const sectionEl = document.createElement('section');
+      sectionEl.className = 'property-grid__section';
+
+      if (section.label) {
+        const header = document.createElement('header');
+        header.className = 'property-grid__section-header';
+        header.textContent = section.label;
+        sectionEl.appendChild(header);
+      }
+
+      const rowsEl = document.createElement('div');
+      rowsEl.className = 'property-grid__section-body';
+      for (const row of section.rows) {
+        const rowEl = this._renderRow(row);
+        if (rowEl) rowsEl.appendChild(rowEl);
+      }
+      sectionEl.appendChild(rowsEl);
+      this.element.appendChild(sectionEl);
+    }
+  }
+
+  _renderRow(row) {
+    const rowEl = document.createElement('div');
+    rowEl.className = 'property-grid__row';
+    if (row.className) rowEl.classList.add(row.className);
+    if (row.readOnly) rowEl.classList.add('is-readonly');
+    if (row.highlight) rowEl.classList.add('is-highlight');
+
+    const labelEl = document.createElement('div');
+    labelEl.className = 'property-grid__label';
+    if (typeof row.label === 'string') {
+      labelEl.textContent = row.label;
+    } else if (row.label instanceof Node) {
+      labelEl.appendChild(row.label);
+    } else if (typeof row.renderLabel === 'function') {
+      const content = row.renderLabel(row) ?? null;
+      if (content instanceof Node) {
+        labelEl.appendChild(content);
+      } else if (content != null) {
+        labelEl.textContent = String(content);
+      }
+    }
+    if (row.description) {
+      const desc = document.createElement('span');
+      desc.className = 'property-grid__label-description';
+      desc.textContent = row.description;
+      labelEl.appendChild(desc);
+    }
+    if (row.tooltip) labelEl.title = row.tooltip;
+
+    const valueEl = document.createElement('div');
+    valueEl.className = 'property-grid__value';
+
+    const editorConfig = {
+      value: row.value,
+      readOnly: row.readOnly,
+      placeholder: row.placeholder,
+      mixed: row.mixed,
+      options: row.options,
+      onCommit: row.onCommit ?? noop,
+      onInput: row.onInput ?? null,
+    };
+
+    let editor = null;
+    try {
+      editor = createEditor(row.type ?? 'text', editorConfig);
+    } catch (err) {
+      console.warn('Failed to create editor for row', row, err);
+      valueEl.textContent = row.value != null ? String(row.value) : '';
+    }
+    if (editor) {
+      valueEl.appendChild(editor.element);
+      if (row.mixed != null && editor.setMixed) {
+        editor.setMixed(row.mixed);
+      }
+      this._activeEditors.push(editor);
+    }
+
+    if (Array.isArray(row.actions) && row.actions.length) {
+      const actionsEl = document.createElement('div');
+      actionsEl.className = 'property-grid__actions';
+      for (const action of row.actions) {
+        if (!action || action.hidden) continue;
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'property-grid__action';
+        if (action.className) {
+          for (const cls of String(action.className).split(/\s+/)) {
+            if (cls) button.classList.add(cls);
+          }
+        }
+        if (action.icon) {
+          button.dataset.icon = action.icon;
+        }
+        if (action.label) {
+          button.title = action.label;
+        }
+        button.textContent = action.text ?? '';
+        button.disabled = Boolean(action.disabled);
+        button.addEventListener('click', event => {
+          event.stopPropagation();
+          if (typeof action.onClick === 'function') {
+            action.onClick(row, event);
+          }
+        });
+        actionsEl.appendChild(button);
+      }
+      valueEl.appendChild(actionsEl);
+    }
+
+    rowEl.append(labelEl, valueEl);
+    if (row.help) {
+      const helpEl = document.createElement('div');
+      helpEl.className = 'property-grid__help';
+      helpEl.textContent = row.help;
+      rowEl.appendChild(helpEl);
+    }
+
+    return rowEl;
+  }
+}

--- a/engine/render/mesh/meshInstance.js
+++ b/engine/render/mesh/meshInstance.js
@@ -47,10 +47,10 @@ class TransformNode extends Instance {
     this._position = cloneVector3({});
     this._scale = cloneScale({ x: 1, y: 1, z: 1 });
     this._rotationQuat = quaternionFromEuler();
-
     super.setProperty('Position', cloneVector3(this._position));
     super.setProperty('Scale', cloneVector3(this._scale));
     super.setProperty('Rotation', cloneVector3(quaternionToEuler(this._rotationQuat)));
+    super.setProperty('Visible', true);
 
     this._localMatrix = mat4Identity();
     this._worldMatrix = mat4Identity();
@@ -64,6 +64,15 @@ class TransformNode extends Instance {
   }
 
   setProperty(name, value) {
+    if (name === 'Visible') {
+      const next = value === undefined ? true : Boolean(value);
+      if (this.Visible === next) {
+        return;
+      }
+      super.setProperty(name, next);
+      return;
+    }
+
     if (name === 'Position') {
       this._position = cloneVector3(value);
       super.setProperty(name, cloneVector3(this._position));
@@ -156,7 +165,7 @@ class TransformNode extends Instance {
   }
 
   isRenderable() {
-    return this.Parent !== null;
+    return this.Parent !== null && this.Visible !== false;
   }
 }
 
@@ -176,6 +185,15 @@ class MeshInstance extends TransformNode {
 
     this.setMesh(mesh, materials);
     drawList.register(this);
+  }
+
+  setProperty(name, value) {
+    if (name === 'Visible') {
+      super.setProperty(name, value);
+      drawList.markDirty();
+      return;
+    }
+    super.setProperty(name, value);
   }
 
   setMesh(mesh, materials = null) {

--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="/editor/ui/icons.css" />
   <link rel="stylesheet" href="/editor/ui/dock/dock.css" />
   <link rel="stylesheet" href="/editor/panes/explorer.css" />
+  <link rel="stylesheet" href="/editor/panes/properties.css" />
   <link rel="stylesheet" href="/editor/ui/tree/tree.css" />
 </head>
 <body>


### PR DESCRIPTION
## Summary
- replace the properties pane with a property grid that supports multi-selection, vector editing, and full attribute management
- add reusable property grid UI components, a suite of property editors, and an HSV-based color picker for color fields
- update undo/redo and rendering to handle visibility toggles and surface the new inspector styling in the app shell

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4b73e7a74832ca4f3fa5d0d5599c1