### PR TITLE
feat(ui): add command registry with menubar and hotkeys

### DIFF
--- a/editor/services/undo.js
+++ b/editor/services/undo.js
@@ -30,6 +30,14 @@ export default class UndoService {
     }
   }
 
+  canUndo() {
+    return this.undoStack.length > 0;
+  }
+
+  canRedo() {
+    return this.redoStack.length > 0;
+  }
+
   // Command helpers
   createInstance(inst, parent) {
     return {

--- a/editor/ui/commands.js
+++ b/editor/ui/commands.js
@@ -1,0 +1,222 @@
+const RESERVED_TYPES = new Set(['command', 'separator']);
+
+function normalizeMenuId(id) {
+  if (typeof id !== 'string' || !id.trim()) {
+    throw new Error('[CommandRegistry] Menu id must be a non-empty string');
+  }
+  return id.trim().toLowerCase();
+}
+
+function normalizeCommandId(id) {
+  if (typeof id !== 'string' || !id.trim()) {
+    throw new Error('[CommandRegistry] Command id must be a non-empty string');
+  }
+  return id.trim().toLowerCase();
+}
+
+function normalizeShortcut(input) {
+  if (!input) return [];
+  if (Array.isArray(input)) {
+    return input
+      .map(item => (typeof item === 'string' ? item.trim() : ''))
+      .filter(Boolean);
+  }
+  if (typeof input === 'string') {
+    const trimmed = input.trim();
+    return trimmed ? [trimmed] : [];
+  }
+  return [];
+}
+
+function shallowCloneCommand(command) {
+  return {
+    ...command,
+    shortcuts: command.shortcuts.slice(),
+  };
+}
+
+export class CommandRegistry {
+  constructor() {
+    this.menus = new Map();
+    this.commands = new Map();
+    this.listeners = new Set();
+  }
+
+  registerMenu({ id, title, order = 0 } = {}) {
+    const key = normalizeMenuId(id);
+    const menu = {
+      id: key,
+      title: typeof title === 'string' && title.trim() ? title.trim() : id,
+      order: Number.isFinite(order) ? order : 0,
+    };
+    this.menus.set(key, menu);
+    this._emit();
+    return () => {
+      if (this.menus.get(key) === menu) {
+        this.menus.delete(key);
+        this._emit();
+      }
+    };
+  }
+
+  registerCommand(definition = {}) {
+    const id = normalizeCommandId(definition.id);
+    if (this.commands.has(id)) {
+      throw new Error(`[CommandRegistry] Command "${id}" already exists`);
+    }
+
+    const menuId = definition.menu ? normalizeMenuId(definition.menu) : null;
+    if (menuId && !this.menus.has(menuId)) {
+      this.registerMenu({ id: menuId, title: definition.menuTitle ?? definition.menu });
+    }
+
+    const type = RESERVED_TYPES.has(definition.type) ? definition.type : 'command';
+    const command = {
+      id,
+      type,
+      title: typeof definition.title === 'string' ? definition.title : '',
+      menu: menuId,
+      order: Number.isFinite(definition.order) ? definition.order : 0,
+      enabled: definition.enabled !== false,
+      checked: Boolean(definition.checked),
+      description: typeof definition.description === 'string' ? definition.description : '',
+      allowInInputs: Boolean(definition.allowInInputs),
+      preventDefault: definition.preventDefault !== false,
+      shortcuts: normalizeShortcut(definition.shortcut),
+      run: typeof definition.run === 'function' ? definition.run : null,
+    };
+
+    this.commands.set(id, command);
+    this._emit();
+
+    return () => {
+      if (this.commands.get(id) === command) {
+        this.commands.delete(id);
+        this._emit();
+      }
+    };
+  }
+
+  updateCommand(id, patch = {}) {
+    const key = normalizeCommandId(id);
+    const existing = this.commands.get(key);
+    if (!existing) return;
+    const next = shallowCloneCommand(existing);
+
+    if (Object.prototype.hasOwnProperty.call(patch, 'title')) {
+      next.title = typeof patch.title === 'string' ? patch.title : existing.title;
+    }
+    if (Object.prototype.hasOwnProperty.call(patch, 'enabled')) {
+      next.enabled = Boolean(patch.enabled);
+    }
+    if (Object.prototype.hasOwnProperty.call(patch, 'checked')) {
+      next.checked = Boolean(patch.checked);
+    }
+    if (Object.prototype.hasOwnProperty.call(patch, 'description')) {
+      next.description = typeof patch.description === 'string' ? patch.description : existing.description;
+    }
+    if (Object.prototype.hasOwnProperty.call(patch, 'allowInInputs')) {
+      next.allowInInputs = Boolean(patch.allowInInputs);
+    }
+    if (Object.prototype.hasOwnProperty.call(patch, 'preventDefault')) {
+      next.preventDefault = Boolean(patch.preventDefault);
+    }
+    if (Object.prototype.hasOwnProperty.call(patch, 'shortcut')) {
+      next.shortcuts = normalizeShortcut(patch.shortcut);
+    }
+    if (Object.prototype.hasOwnProperty.call(patch, 'run')) {
+      next.run = typeof patch.run === 'function' ? patch.run : existing.run;
+    }
+    if (Object.prototype.hasOwnProperty.call(patch, 'menu')) {
+      const menuId = patch.menu ? normalizeMenuId(patch.menu) : null;
+      next.menu = menuId;
+      if (menuId && !this.menus.has(menuId)) {
+        this.registerMenu({ id: menuId, title: patch.menuTitle ?? patch.menu });
+      }
+    }
+    if (Object.prototype.hasOwnProperty.call(patch, 'order')) {
+      next.order = Number.isFinite(patch.order) ? patch.order : existing.order;
+    }
+    if (Object.prototype.hasOwnProperty.call(patch, 'type') && RESERVED_TYPES.has(patch.type)) {
+      next.type = patch.type;
+    }
+
+    this.commands.set(key, next);
+    this._emit();
+  }
+
+  setEnabled(id, value) {
+    this.updateCommand(id, { enabled: Boolean(value) });
+  }
+
+  setChecked(id, value) {
+    this.updateCommand(id, { checked: Boolean(value) });
+  }
+
+  execute(id, context) {
+    const key = normalizeCommandId(id);
+    const command = this.commands.get(key);
+    if (!command || command.type !== 'command' || !command.enabled) {
+      return undefined;
+    }
+    if (typeof command.run !== 'function') {
+      return undefined;
+    }
+    try {
+      return command.run({ id: command.id, ...context });
+    } catch (err) {
+      console.error(`[CommandRegistry] Failed to execute command "${command.id}"`, err);
+      return undefined;
+    }
+  }
+
+  getMenus() {
+    return Array.from(this.menus.values())
+      .slice()
+      .sort((a, b) => {
+        if (a.order === b.order) {
+          return a.title.localeCompare(b.title);
+        }
+        return a.order - b.order;
+      });
+  }
+
+  getCommands(menuId) {
+    const key = menuId ? normalizeMenuId(menuId) : null;
+    return Array.from(this.commands.values())
+      .filter(cmd => cmd.menu === key)
+      .sort((a, b) => {
+        if (a.order === b.order) {
+          return a.title.localeCompare(b.title);
+        }
+        return a.order - b.order;
+      });
+  }
+
+  getCommand(id) {
+    const key = normalizeCommandId(id);
+    const command = this.commands.get(key);
+    return command ? shallowCloneCommand(command) : null;
+  }
+
+  subscribe(listener) {
+    if (typeof listener !== 'function') return () => {};
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  _emit() {
+    if (!this.listeners.size) return;
+    for (const listener of this.listeners) {
+      try {
+        listener(this);
+      } catch (err) {
+        console.error('[CommandRegistry] Listener error', err);
+      }
+    }
+  }
+}
+
+export default CommandRegistry;

--- a/editor/ui/hotkeys.js
+++ b/editor/ui/hotkeys.js
@@ -1,0 +1,201 @@
+const MAC_PLATFORM = /Mac|iPod|iPhone|iPad/.test(navigator.platform || navigator.userAgent || '');
+
+const MODIFIER_KEYS = new Set(['ctrl', 'shift', 'alt', 'meta']);
+
+function normalizeKey(key) {
+  if (!key) return '';
+  const normalized = key.length === 1 ? key.toLowerCase() : key.toLowerCase();
+  return normalized;
+}
+
+function parseShortcut(shortcut) {
+  if (typeof shortcut !== 'string' || !shortcut.trim()) return null;
+  const parts = shortcut.split('+').map(part => part.trim()).filter(Boolean);
+  if (!parts.length) return null;
+
+  const config = {
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+    key: '',
+    code: '',
+  };
+
+  for (const partRaw of parts) {
+    const part = partRaw.toLowerCase();
+    if (part === 'mod') {
+      if (MAC_PLATFORM) config.metaKey = true;
+      else config.ctrlKey = true;
+      continue;
+    }
+    if (part === 'cmd' || part === 'command') {
+      config.metaKey = true;
+      continue;
+    }
+    if (part === 'ctrl' || part === 'control') {
+      config.ctrlKey = true;
+      continue;
+    }
+    if (part === 'shift') {
+      config.shiftKey = true;
+      continue;
+    }
+    if (part === 'alt' || part === 'option') {
+      config.altKey = true;
+      continue;
+    }
+    if (part.startsWith('f') && part.length <= 3 && !Number.isNaN(Number(part.slice(1)))) {
+      config.key = part;
+      config.code = part.toUpperCase();
+      continue;
+    }
+    config.key = normalizeKey(partRaw);
+  }
+
+  if (!config.key) {
+    const last = parts[parts.length - 1];
+    if (last && !MODIFIER_KEYS.has(last.toLowerCase())) {
+      config.key = normalizeKey(last);
+    }
+  }
+
+  return config.key ? config : null;
+}
+
+function isEditableTarget(target) {
+  if (!target) return false;
+  const tag = target.tagName;
+  if (!tag) return false;
+  const lower = tag.toLowerCase();
+  if (lower === 'input' || lower === 'textarea' || lower === 'select') return true;
+  if (target.isContentEditable) return true;
+  return target.closest?.('[contenteditable="true"]');
+}
+
+export function isMacPlatform() {
+  return MAC_PLATFORM;
+}
+
+export function formatShortcut(shortcut) {
+  if (!shortcut) return '';
+  const tokens = shortcut.split('+').map(token => token.trim()).filter(Boolean);
+  if (!tokens.length) return '';
+  const formatted = [];
+  if (MAC_PLATFORM) {
+    for (const tokenRaw of tokens) {
+      const token = tokenRaw.toLowerCase();
+      if (token === 'mod' || token === 'cmd' || token === 'command') formatted.push('⌘');
+      else if (token === 'shift') formatted.push('⇧');
+      else if (token === 'ctrl' || token === 'control') formatted.push('⌃');
+      else if (token === 'alt' || token === 'option') formatted.push('⌥');
+      else formatted.push(tokenRaw.toUpperCase());
+    }
+    return formatted.join('');
+  }
+  return tokens
+    .map(token => {
+      const lower = token.toLowerCase();
+      if (lower === 'mod') return 'Ctrl';
+      if (lower === 'cmd' || lower === 'command') return 'Ctrl';
+      if (lower === 'ctrl' || lower === 'control') return 'Ctrl';
+      if (lower === 'shift') return 'Shift';
+      if (lower === 'alt' || lower === 'option') return 'Alt';
+      return token.length === 1 ? token.toUpperCase() : token;
+    })
+    .join('+');
+}
+
+export class HotkeyManager {
+  constructor(registry, { target = window } = {}) {
+    this.registry = registry;
+    this.target = target;
+    this._bindings = new Map();
+
+    this._handleKeyDown = event => this._onKeyDown(event);
+    this._unsubscribe = this.registry.subscribe(() => this._rebuild());
+
+    this._attach();
+    this._rebuild();
+  }
+
+  dispose() {
+    this._detach();
+    if (typeof this._unsubscribe === 'function') {
+      this._unsubscribe();
+    }
+  }
+
+  _attach() {
+    if (this.target && typeof this.target.addEventListener === 'function') {
+      this.target.addEventListener('keydown', this._handleKeyDown, { capture: true });
+    }
+  }
+
+  _detach() {
+    if (this.target && typeof this.target.removeEventListener === 'function') {
+      this.target.removeEventListener('keydown', this._handleKeyDown, { capture: true });
+    }
+  }
+
+  _rebuild() {
+    this._bindings.clear();
+    const menus = this.registry.getMenus();
+    for (const menu of menus) {
+      const commands = this.registry.getCommands(menu.id);
+      for (const command of commands) {
+        if (!command.shortcuts?.length) continue;
+        for (const shortcut of command.shortcuts) {
+          const parsed = parseShortcut(shortcut);
+          if (!parsed) continue;
+          const key = parsed.key;
+          if (!this._bindings.has(key)) {
+            this._bindings.set(key, []);
+          }
+          this._bindings.get(key).push({
+            commandId: command.id,
+            config: parsed,
+          });
+        }
+      }
+    }
+  }
+
+  _matches(event, config) {
+    if (!config) return false;
+    const eventKey = normalizeKey(event.key || event.code);
+    if (eventKey !== config.key && event.code?.toLowerCase() !== config.key) {
+      return false;
+    }
+    if (config.ctrlKey !== event.ctrlKey) return false;
+    if (config.metaKey !== event.metaKey) return false;
+    if (config.altKey !== event.altKey) return false;
+    if (config.shiftKey !== event.shiftKey) return false;
+    return true;
+  }
+
+  _onKeyDown(event) {
+    if (!event || event.defaultPrevented) return;
+    const key = normalizeKey(event.key || event.code);
+    if (!key) return;
+    const candidates = this._bindings.get(key);
+    if (!candidates || !candidates.length) return;
+
+    for (const candidate of candidates) {
+      const { commandId, config } = candidate;
+      if (!this._matches(event, config)) continue;
+      const command = this.registry.getCommand(commandId);
+      if (!command || command.type !== 'command' || !command.enabled) continue;
+      if (!command.allowInInputs && isEditableTarget(event.target)) {
+        continue;
+      }
+      if (command.preventDefault !== false) {
+        event.preventDefault();
+      }
+      this.registry.execute(command.id, { source: 'hotkey', event });
+      break;
+    }
+  }
+}
+
+export default HotkeyManager;

--- a/editor/ui/menubar.js
+++ b/editor/ui/menubar.js
@@ -1,0 +1,191 @@
+import { formatShortcut } from './hotkeys.js';
+
+const MENU_CLASS = 'menubar__menu';
+const OPEN_CLASS = 'is-open';
+
+function createElement(tag, className) {
+  const el = document.createElement(tag);
+  if (className) {
+    el.className = className;
+  }
+  return el;
+}
+
+function isMenuButton(target) {
+  return target?.dataset?.menuButton === 'true';
+}
+
+function isCommandButton(target) {
+  return target?.dataset?.commandId;
+}
+
+export class Menubar {
+  constructor(registry) {
+    this.registry = registry;
+    this.element = createElement('nav', 'menubar');
+    this._openMenuId = null;
+    this._menuNodes = new Map();
+
+    this._handleRegistryUpdate = () => this._render();
+    this._handleDocumentClick = event => this._onDocumentClick(event);
+    this._handleKeyDown = event => this._onKeyDown(event);
+    this._handleWindowBlur = () => this.close();
+
+    this.registry.subscribe(this._handleRegistryUpdate);
+    document.addEventListener('click', this._handleDocumentClick);
+    window.addEventListener('blur', this._handleWindowBlur);
+    this.element.addEventListener('keydown', this._handleKeyDown);
+
+    this._render();
+  }
+
+  dispose() {
+    document.removeEventListener('click', this._handleDocumentClick);
+    this.element.removeEventListener('keydown', this._handleKeyDown);
+    window.removeEventListener('blur', this._handleWindowBlur);
+  }
+
+  close() {
+    if (!this._openMenuId) return;
+    const menu = this._menuNodes.get(this._openMenuId);
+    if (menu) {
+      menu.classList.remove(OPEN_CLASS);
+      const dropdown = menu.querySelector('.menubar__dropdown');
+      if (dropdown) dropdown.setAttribute('aria-hidden', 'true');
+    }
+    this._openMenuId = null;
+  }
+
+  _render() {
+    const currentOpen = this._openMenuId;
+    this._menuNodes.clear();
+    this.element.textContent = '';
+
+    const menus = this.registry.getMenus();
+    for (const menu of menus) {
+      const container = createElement('div', MENU_CLASS);
+      container.dataset.menuId = menu.id;
+
+      const button = createElement('button', 'menubar__item');
+      button.type = 'button';
+      button.dataset.menuButton = 'true';
+      button.dataset.menuId = menu.id;
+      button.textContent = menu.title;
+      button.addEventListener('click', event => this._toggleMenu(menu.id, event));
+      button.addEventListener('mouseenter', () => {
+        if (this._openMenuId && this._openMenuId !== menu.id) {
+          this._openSpecificMenu(menu.id, { focusButton: false });
+        }
+      });
+
+      const dropdown = createElement('div', 'menubar__dropdown');
+      dropdown.setAttribute('role', 'menu');
+      dropdown.setAttribute('aria-hidden', 'true');
+
+      const commands = this.registry.getCommands(menu.id);
+      for (const command of commands) {
+        if (command.type === 'separator') {
+          const separator = createElement('div', 'menubar__separator');
+          dropdown.appendChild(separator);
+          continue;
+        }
+        const commandButton = createElement('button', 'menubar__command');
+        commandButton.type = 'button';
+        commandButton.dataset.commandId = command.id;
+        commandButton.disabled = !command.enabled;
+        commandButton.setAttribute('role', 'menuitem');
+        commandButton.addEventListener('click', event => this._handleCommandClick(command.id, event));
+
+        if (command.checked) {
+          commandButton.classList.add('is-checked');
+        }
+
+        const label = createElement('span', 'menubar__command-label');
+        const indicator = createElement('span', 'menubar__command-indicator');
+        indicator.setAttribute('aria-hidden', 'true');
+        indicator.textContent = command.checked ? '✓' : '';
+        label.append(indicator, document.createTextNode(command.title));
+
+        const shortcut = createElement('span', 'menubar__command-shortcut');
+        shortcut.textContent = command.shortcuts.length ? formatShortcut(command.shortcuts[0]) : '';
+
+        commandButton.append(label, shortcut);
+        dropdown.appendChild(commandButton);
+      }
+
+      container.append(button, dropdown);
+      this.element.appendChild(container);
+      this._menuNodes.set(menu.id, container);
+    }
+
+    if (currentOpen) {
+      this._openSpecificMenu(currentOpen, { focusButton: false });
+    }
+  }
+
+  _toggleMenu(menuId, event) {
+    if (event) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+    if (this._openMenuId === menuId) {
+      this.close();
+      return;
+    }
+    this._openSpecificMenu(menuId, { focusButton: true });
+  }
+
+  _openSpecificMenu(menuId, { focusButton } = {}) {
+    if (this._openMenuId && this._openMenuId !== menuId) {
+      this.close();
+    }
+    const menu = this._menuNodes.get(menuId);
+    if (!menu) {
+      this._openMenuId = null;
+      return;
+    }
+    menu.classList.add(OPEN_CLASS);
+    const dropdown = menu.querySelector('.menubar__dropdown');
+    if (dropdown) {
+      dropdown.setAttribute('aria-hidden', 'false');
+    }
+    const button = menu.querySelector('[data-menu-button="true"]');
+    if (focusButton && button) {
+      button.focus();
+    }
+    this._openMenuId = menuId;
+  }
+
+  _handleCommandClick(commandId, event) {
+    if (event) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+    this.registry.execute(commandId, { source: 'menubar', event });
+    this.close();
+  }
+
+  _onDocumentClick(event) {
+    if (!event) return;
+    const target = event.target;
+    if (this.element.contains(target)) {
+      if (isMenuButton(target)) return;
+      if (isCommandButton(target)) return;
+    }
+    this.close();
+  }
+
+  _onKeyDown(event) {
+    if (event.key === 'Escape' && this._openMenuId) {
+      const openMenuId = this._openMenuId;
+      this.close();
+      const menu = this._menuNodes.get(openMenuId);
+      const button = menu?.querySelector('[data-menu-button="true"]');
+      if (button) button.focus();
+      event.stopPropagation();
+      event.preventDefault();
+    }
+  }
+}
+
+export default Menubar;

--- a/editor/ui/theme.css
+++ b/editor/ui/theme.css
@@ -90,6 +90,14 @@ button, input, select, textarea {
   border-bottom: 1px solid var(--outline);
   font-size: 0.9rem;
   letter-spacing: 0.02em;
+  position: relative;
+  z-index: 20;
+}
+
+.menubar__menu {
+  position: relative;
+  display: flex;
+  align-items: stretch;
 }
 
 .menubar__item {
@@ -102,10 +110,91 @@ button, input, select, textarea {
   display: flex;
   align-items: center;
   transition: background var(--transition-fast), color var(--transition-fast);
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
 }
 
-.menubar__item:hover {
-  background: rgba(255, 255, 255, 0.06);
+.menubar__item:hover,
+.menubar__menu.is-open > .menubar__item {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.menubar__dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  min-width: 12rem;
+  margin-top: 0.25rem;
+  padding: 0.35rem 0;
+  background: rgba(24, 24, 26, 0.96);
+  backdrop-filter: blur(18px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.5rem;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+  display: none;
+}
+
+.menubar__menu.is-open > .menubar__dropdown {
+  display: block;
+}
+
+.menubar__command {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.25rem;
+  width: 100%;
+  padding: 0.35rem 0.75rem;
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.menubar__command:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.menubar__command[disabled] {
+  opacity: 0.45;
+  cursor: default;
+  pointer-events: none;
+}
+
+.menubar__command-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.menubar__command-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  font-size: 0.75rem;
+  color: var(--accent, #6fc1ff);
+}
+
+.menubar__command-shortcut {
+  opacity: 0.65;
+  font-size: 0.8rem;
+  letter-spacing: 0.05em;
+}
+
+.menubar__separator {
+  height: 1px;
+  margin: 0.25rem 0;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.menubar__command.is-checked {
+  color: var(--accent, #6fc1ff);
 }
 
 .toolbar {


### PR DESCRIPTION
## Summary
- add a shared command registry, menubar component, and hotkey manager to drive editor actions
- integrate the shell with command-driven menus, panel toggles, run/theme/fullscreen controls, and undo-aware edit commands
- extend dock and undo services plus UI styling to support panel visibility, command state, and dropdown presentation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4c0fd1d98832c9076401df2d7f937