### PR TITLE
feat: redesign asset manager with drag assignments

### DIFF
--- a/editor/panes/assets.css
+++ b/editor/panes/assets.css
@@ -1,0 +1,307 @@
+.assets-pane {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: rgba(20, 24, 32, 0.92);
+  color: #eef2ff;
+  font-family: 'Inter', system-ui, sans-serif;
+}
+
+.assets-pane__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  gap: 12px;
+}
+
+.assets-pane__toolbar-left,
+.assets-pane__toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.assets-pane__filters {
+  display: inline-flex;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  padding: 4px;
+  gap: 4px;
+}
+
+.assets-pane__filters button {
+  background: transparent;
+  color: #cdd6f4;
+  border: none;
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.assets-pane__filters button.is-active {
+  background: rgba(99, 102, 241, 0.28);
+  color: #ffffff;
+}
+
+.assets-pane__filters button:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.assets-pane__view-toggle {
+  display: inline-flex;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  padding: 4px;
+  gap: 4px;
+}
+
+.assets-pane__view-toggle button {
+  border: none;
+  background: transparent;
+  color: #cdd6f4;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 6px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.assets-pane__view-toggle button.is-active {
+  background: rgba(99, 102, 241, 0.28);
+  color: #ffffff;
+}
+
+.assets-pane__search {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.assets-pane__search input {
+  background: rgba(8, 10, 18, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  padding: 6px 10px;
+  color: #eef2ff;
+  font-size: 13px;
+  min-width: 200px;
+}
+
+.assets-pane__search input::placeholder {
+  color: rgba(205, 214, 244, 0.6);
+}
+
+.assets-pane__content {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+.assets-browser {
+  flex: 1;
+  overflow: auto;
+  padding: 16px;
+}
+
+.assets-browser__items {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 12px;
+  align-content: start;
+}
+
+.assets-browser__items.is-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.asset-card {
+  background: rgba(10, 12, 20, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  padding: 10px;
+  cursor: pointer;
+  transition: border 120ms ease, transform 120ms ease, background 120ms ease;
+}
+
+.asset-card:hover {
+  border-color: rgba(148, 163, 255, 0.5);
+  background: rgba(14, 18, 28, 0.85);
+}
+
+.asset-card.is-selected {
+  border-color: rgba(129, 140, 248, 0.9);
+  background: rgba(17, 24, 39, 0.92);
+}
+
+.asset-card__thumb {
+  position: relative;
+  padding-bottom: 75%;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 8px;
+  overflow: hidden;
+  margin-bottom: 8px;
+}
+
+.asset-card__thumb img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.asset-card__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.asset-card__name {
+  font-size: 13px;
+  font-weight: 600;
+  color: #f8fafc;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.asset-card__type {
+  font-size: 11px;
+  color: rgba(226, 232, 255, 0.72);
+}
+
+.asset-card__path {
+  font-size: 10px;
+  color: rgba(148, 163, 184, 0.6);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.assets-browser__empty {
+  padding: 48px 16px;
+  text-align: center;
+  color: rgba(226, 232, 255, 0.65);
+  font-size: 14px;
+}
+
+.assets-pane__preview {
+  width: 320px;
+  border-left: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 16px;
+  background: rgba(6, 8, 12, 0.85);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.assets-pane__actions button,
+.assets-pane__toolbar button {
+  border: none;
+  background: rgba(99, 102, 241, 0.2);
+  color: #ffffff;
+  border-radius: 8px;
+  padding: 8px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 120ms ease, background 120ms ease;
+}
+
+.assets-pane__actions button:hover,
+.assets-pane__toolbar button:hover {
+  background: rgba(129, 140, 248, 0.4);
+}
+
+.assets-pane__actions button:active,
+.assets-pane__toolbar button:active {
+  transform: scale(0.98);
+}
+
+.asset-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.asset-preview__thumb {
+  position: relative;
+  width: 100%;
+  padding-bottom: 75%;
+  border-radius: 12px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.04);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(226, 232, 255, 0.6);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.asset-preview__thumb--empty {
+  background: rgba(15, 23, 42, 0.6);
+  color: rgba(148, 163, 184, 0.6);
+}
+
+.asset-preview__image {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.asset-preview__placeholder {
+  pointer-events: none;
+}
+
+.asset-preview__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.asset-preview__meta-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+}
+
+.asset-preview__meta-key {
+  color: rgba(148, 163, 184, 0.7);
+  font-weight: 600;
+}
+
+.asset-preview__meta-value {
+  color: #f8fafc;
+  text-align: right;
+}
+
+.property-grid .is-drop-target {
+  outline: 2px dashed rgba(129, 140, 248, 0.8);
+  outline-offset: 2px;
+}
+
+.asset-card.is-drop-target {
+  border-color: rgba(129, 140, 248, 0.8);
+}
+
+.assets-pane__footer {
+  padding: 12px 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 12px;
+  color: rgba(226, 232, 255, 0.65);
+}

--- a/editor/panes/assets.js
+++ b/editor/panes/assets.js
@@ -4,33 +4,131 @@ import { getWorkspace } from '../../engine/scene/workspace.js';
 import { tryGetDevice } from '../../engine/render/gpu/device.js';
 import { showToast } from '../ui/toast.js';
 import { showProgress, hideProgress } from '../ui/progress.js';
+import showContextMenu from '../ui/contextmenu.js';
+import AssetPreview from '../ui/preview/preview.js';
+import { registerDragSource } from '../ui/dropdrag.js';
+import MaterialRegistry from '../services/materialRegistry.js';
 
-// Basic Asset Manager pane providing import and listing features.
+const TYPE_LABELS = {
+  textures: 'Texture',
+  materials: 'Material',
+  models: 'Mesh',
+  audio: 'Audio',
+  unknown: 'Unknown',
+};
+
+const FILTERS = [
+  { id: 'all', label: 'All' },
+  { id: 'textures', label: 'Textures' },
+  { id: 'materials', label: 'Materials' },
+  { id: 'models', label: 'Meshes' },
+  { id: 'audio', label: 'Audio' },
+];
+
+function normalizeName(asset) {
+  return asset?.name || asset?.logicalPath || asset?.guid || 'Asset';
+}
+
+function matchFilter(asset, filter) {
+  if (!filter || filter === 'all') return true;
+  return asset?.type === filter;
+}
+
+function matchSearch(asset, query) {
+  if (!query) return true;
+  const haystack = `${asset?.name ?? ''} ${asset?.logicalPath ?? ''}`.toLowerCase();
+  return haystack.includes(query);
+}
+
+function formatType(asset) {
+  return TYPE_LABELS[asset?.type] || 'Asset';
+}
+
+function formatStatus(asset) {
+  if (!asset) return '';
+  if (asset.status === 'decoded') return 'Embedded';
+  if (asset.status === 'external') return 'Linked';
+  if (asset.status === 'missing') return 'Missing';
+  return asset.status || '';
+}
+
 export default class AssetsPane {
   constructor(service = new AssetService(), options = {}) {
+    const { floatingUI = true, materials = MaterialRegistry } = options ?? {};
     this.service = service;
+    this.materials = materials;
     this.workspace = getWorkspace();
-    const { floatingUI = true } = options ?? {};
-    if (floatingUI) {
-      this._setupUI();
+    this.assets = [];
+    this.filtered = [];
+    this.selection = null;
+    this.filter = 'all';
+    this.viewMode = 'grid';
+    this.searchQuery = '';
+    this.hasDOM = typeof document !== 'undefined';
+    this._dragDisposers = new Map();
+
+    if (this.hasDOM) {
+      this.element = this._createRoot();
+      if (floatingUI) {
+        this._setupFloatingImport();
+      }
+    } else {
+      this.element = null;
+    }
+
+    this._changeListener = this.service.on('change', () => {
+      this.refresh();
+    });
+
+    this.refresh();
+  }
+
+  dispose() {
+    if (typeof this._changeListener === 'function') {
+      this._changeListener();
+      this._changeListener = null;
+    }
+    for (const dispose of this._dragDisposers.values()) {
+      dispose?.();
+    }
+    this._dragDisposers.clear();
+    if (this.preview) {
+      this.preview.dispose();
+    }
+    if (this.element && this.element.parentElement) {
+      this.element.parentElement.removeChild(this.element);
     }
   }
 
-  // Import an array of File objects or paths.
   async import(files) {
-    const arr = Array.isArray(files) ? files : [files];
-    for (const file of arr) {
-      await this.service.import(file);
+    const list = Array.isArray(files) ? files : [files];
+    const results = [];
+    for (const file of list) {
+      const label = typeof file === 'string' ? file.split('/').pop() : file?.name || 'asset';
+      const progressId = `import:${label}:${Date.now()}`;
+      showProgress(progressId, { title: `Importing ${label}`, percent: 0.1 });
+      try {
+        const asset = await this.service.import(file);
+        showProgress(progressId, { title: `Finalizing ${label}`, percent: 1 });
+        window.setTimeout(() => hideProgress(progressId), 240);
+        results.push(asset);
+        showToast(`Imported ${label}`, 'success', 2400);
+      } catch (err) {
+        hideProgress(progressId);
+        const detail = err?.message ? `: ${err.message}` : '';
+        showToast(`Failed to import ${label}${detail}`, 'error', 3600);
+        console.error('[Assets] Import failed', file, err);
+      }
     }
-    return this.list();
+    await this.refresh();
+    return results;
   }
 
-  // Retrieve list of assets with status information.
   async list() {
-    return await this.service.list();
+    const entries = await this.service.list();
+    return entries;
   }
 
-  // Get a logical URI for an asset suitable for runtime resolution.
   copyPath(asset) {
     return this.service.getURI(asset);
   }
@@ -62,7 +160,386 @@ export default class AssetsPane {
     }
   }
 
-  _setupUI() {
+  async refresh() {
+    try {
+      const assets = await this.list();
+      this.assets = assets;
+      this._applyFilters();
+    } catch (err) {
+      console.error('[Assets] Failed to refresh', err);
+    }
+  }
+
+  _createRoot() {
+    const root = document.createElement('div');
+    root.className = 'assets-pane';
+
+    const toolbar = document.createElement('div');
+    toolbar.className = 'assets-pane__toolbar';
+
+    const left = document.createElement('div');
+    left.className = 'assets-pane__toolbar-left';
+
+    const importButton = document.createElement('button');
+    importButton.type = 'button';
+    importButton.textContent = 'Import…';
+    left.appendChild(importButton);
+
+    const fileInput = document.createElement('input');
+    fileInput.type = 'file';
+    fileInput.multiple = true;
+    fileInput.style.display = 'none';
+    importButton.addEventListener('click', () => {
+      fileInput.value = '';
+      fileInput.click();
+    });
+    fileInput.addEventListener('change', event => {
+      const files = Array.from(event.target.files || []);
+      if (files.length) {
+        this.import(files);
+      }
+    });
+
+    const filters = document.createElement('div');
+    filters.className = 'assets-pane__filters';
+    for (const entry of FILTERS) {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = entry.label;
+      if (entry.id === this.filter) {
+        button.classList.add('is-active');
+      }
+      button.addEventListener('click', () => {
+        this.filter = entry.id;
+        for (const child of filters.children) {
+          child.classList.toggle('is-active', child === button);
+        }
+        this._applyFilters();
+      });
+      filters.appendChild(button);
+    }
+    left.appendChild(filters);
+    left.appendChild(fileInput);
+
+    const right = document.createElement('div');
+    right.className = 'assets-pane__toolbar-right';
+
+    const viewToggle = document.createElement('div');
+    viewToggle.className = 'assets-pane__view-toggle';
+    const gridButton = document.createElement('button');
+    gridButton.type = 'button';
+    gridButton.textContent = 'Grid';
+    const listButton = document.createElement('button');
+    listButton.type = 'button';
+    listButton.textContent = 'List';
+    const updateViewButtons = () => {
+      gridButton.classList.toggle('is-active', this.viewMode === 'grid');
+      listButton.classList.toggle('is-active', this.viewMode === 'list');
+      this._applyViewMode();
+    };
+    gridButton.addEventListener('click', () => {
+      this.viewMode = 'grid';
+      updateViewButtons();
+    });
+    listButton.addEventListener('click', () => {
+      this.viewMode = 'list';
+      updateViewButtons();
+    });
+    viewToggle.append(gridButton, listButton);
+
+    const searchWrap = document.createElement('div');
+    searchWrap.className = 'assets-pane__search';
+    const searchInput = document.createElement('input');
+    searchInput.type = 'search';
+    searchInput.placeholder = 'Search assets…';
+    searchInput.addEventListener('input', () => {
+      this.searchQuery = searchInput.value.trim().toLowerCase();
+      this._applyFilters();
+    });
+    searchInput.addEventListener('keydown', event => {
+      if (event.key === 'Escape' && searchInput.value) {
+        searchInput.value = '';
+        this.searchQuery = '';
+        this._applyFilters();
+        event.stopPropagation();
+      }
+    });
+    searchWrap.appendChild(searchInput);
+
+    right.append(viewToggle, searchWrap);
+    toolbar.append(left, right);
+
+    const content = document.createElement('div');
+    content.className = 'assets-pane__content';
+
+    const browser = document.createElement('div');
+    browser.className = 'assets-browser';
+
+    const items = document.createElement('div');
+    items.className = 'assets-browser__items';
+    browser.appendChild(items);
+
+    const previewHost = document.createElement('aside');
+    previewHost.className = 'assets-pane__preview';
+    this.preview = new AssetPreview();
+    previewHost.appendChild(this.preview.element);
+
+    const footer = document.createElement('div');
+    footer.className = 'assets-pane__footer';
+    footer.textContent = 'Drag assets into the scene or material slots to assign.';
+
+    content.append(browser, previewHost);
+    root.append(toolbar, content, footer);
+
+    this.importButton = importButton;
+    this.fileInput = fileInput;
+    this.itemsHost = items;
+    this.browser = browser;
+    this.footer = footer;
+
+    updateViewButtons();
+
+    return root;
+  }
+
+  _applyFilters() {
+    this.filtered = this.assets
+      .filter(asset => matchFilter(asset, this.filter))
+      .filter(asset => matchSearch(asset, this.searchQuery))
+      .sort((a, b) => normalizeName(a).localeCompare(normalizeName(b)));
+    this._renderAssets();
+  }
+
+  _applyViewMode() {
+    if (!this.itemsHost) return;
+    this.itemsHost.classList.toggle('is-list', this.viewMode === 'list');
+  }
+
+  _renderAssets() {
+    if (!this.itemsHost) return;
+    this._applyViewMode();
+    this.itemsHost.textContent = '';
+    this._dragDisposers.forEach(dispose => dispose?.());
+    this._dragDisposers.clear();
+
+    if (!this.filtered.length) {
+      const empty = document.createElement('div');
+      empty.className = 'assets-browser__empty';
+      empty.textContent = this.searchQuery
+        ? 'No assets match your search.'
+        : 'Import files to populate your project assets.';
+      this.itemsHost.appendChild(empty);
+      this.preview?.setAsset(null);
+      return;
+    }
+
+    const frag = document.createDocumentFragment();
+    for (const asset of this.filtered) {
+      const card = this._createCard(asset);
+      frag.appendChild(card);
+    }
+    this.itemsHost.appendChild(frag);
+
+    if (this.selection) {
+      const selected = this.filtered.find(entry => entry.guid === this.selection.guid);
+      if (selected) {
+        this._selectAsset(selected, false);
+      } else {
+        this._selectAsset(this.filtered[0] ?? null, false);
+      }
+    } else {
+      this._selectAsset(this.filtered[0] ?? null, false);
+    }
+  }
+
+  _createCard(asset) {
+    const card = document.createElement('div');
+    card.className = 'asset-card';
+    if (asset.guid) {
+      card.dataset.guid = asset.guid;
+    }
+
+    const thumb = document.createElement('div');
+    thumb.className = 'asset-card__thumb';
+    const img = document.createElement('img');
+    img.alt = '';
+    if (asset.thumbnail) {
+      img.src = asset.thumbnail;
+    }
+    thumb.appendChild(img);
+
+    const meta = document.createElement('div');
+    meta.className = 'asset-card__meta';
+    const name = document.createElement('div');
+    name.className = 'asset-card__name';
+    name.textContent = normalizeName(asset);
+    const type = document.createElement('div');
+    type.className = 'asset-card__type';
+    type.textContent = `${formatType(asset)} · ${formatStatus(asset)}`.trim();
+    const path = document.createElement('div');
+    path.className = 'asset-card__path';
+    path.textContent = asset.logicalPath || '';
+    meta.append(name, type, path);
+
+    card.append(thumb, meta);
+
+    card.addEventListener('click', event => {
+      event.preventDefault();
+      this._selectAsset(asset, true);
+    });
+    card.addEventListener('dblclick', () => {
+      this._handleActivate(asset);
+    });
+    card.addEventListener('contextmenu', event => {
+      showContextMenu(event, this._buildContextMenu(asset));
+    });
+
+    const dispose = registerDragSource(card, () => ({
+      type: `asset/${asset.type || 'unknown'}`,
+      kind: 'asset',
+      guid: asset.guid,
+      assetType: asset.type,
+      name: normalizeName(asset),
+      label: normalizeName(asset),
+    }));
+    if (asset.guid) {
+      this._dragDisposers.set(asset.guid, dispose);
+    }
+
+    if (this.selection && this.selection.guid === asset.guid) {
+      card.classList.add('is-selected');
+    }
+
+    return card;
+  }
+
+  _selectAsset(asset, focus = false) {
+    this.selection = asset || null;
+    if (this.preview) {
+      this.preview.setAsset(asset || null);
+    }
+    if (!this.itemsHost) return;
+    for (const child of this.itemsHost.children) {
+      child.classList?.remove('is-selected');
+    }
+    if (asset?.guid) {
+      const card = this.itemsHost.querySelector?.(`.asset-card[data-guid="${asset.guid}"]`);
+      if (card) {
+        card.classList.add('is-selected');
+        if (focus) {
+          card.scrollIntoView({ block: 'nearest' });
+        }
+      }
+    }
+  }
+
+  _handleActivate(asset) {
+    if (!asset) return;
+    if (asset.type === 'models' && asset.source?.value) {
+      this.importGLTF(asset.source.value).catch(err => {
+        console.error('[Assets] Failed to activate model', err);
+      });
+    }
+  }
+
+  _buildContextMenu(asset) {
+    const items = [];
+    items.push({
+      label: 'Reveal in Explorer',
+      action: () => {
+        this._revealAsset(asset);
+      },
+      disabled: asset?.type !== 'models',
+    });
+    items.push({
+      label: 'Rename…',
+      action: () => this._promptRename(asset),
+    });
+    items.push({
+      label: 'Duplicate',
+      action: () => this._duplicate(asset),
+    });
+    items.push({ type: 'separator' });
+    items.push({
+      label: 'Reimport…',
+      action: () => this._promptReimport(asset),
+    });
+    items.push({
+      label: 'Delete',
+      action: () => this._delete(asset),
+    });
+    return items;
+  }
+
+  async _promptRename(asset) {
+    if (!asset) return;
+    const next = window.prompt('Rename asset', normalizeName(asset));
+    if (!next || next === asset.name) return;
+    await this.service.rename(asset.guid, next);
+    await this.refresh();
+  }
+
+  async _duplicate(asset) {
+    if (!asset) return;
+    await this.service.duplicate(asset.guid);
+    await this.refresh();
+  }
+
+  async _promptReimport(asset) {
+    if (!asset) return;
+    if (asset.source?.kind === 'path') {
+      try {
+        await this.service.reimport(asset.guid);
+        const updated = await this.service.get(asset.guid);
+        await this.materials.refreshAssignmentsForAsset(updated, guid => this.service.get(guid));
+        await this.refresh();
+        showToast(`Reimported ${normalizeName(asset)}`, 'success', 2200);
+      } catch (err) {
+        console.error('[Assets] Reimport failed', err);
+        showToast(`Reimport failed: ${err.message}`, 'error', 3200);
+      }
+      return;
+    }
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '';
+    input.style.display = 'none';
+    input.addEventListener('change', async () => {
+      const file = input.files?.[0];
+      if (!file) return;
+      try {
+        await this.service.reimport(asset.guid, file);
+        const updated = await this.service.get(asset.guid);
+        await this.materials.refreshAssignmentsForAsset(updated, guid => this.service.get(guid));
+        await this.refresh();
+        showToast(`Reimported ${normalizeName(asset)}`, 'success', 2200);
+      } catch (err) {
+        console.error('[Assets] Reimport failed', err);
+        showToast(`Reimport failed: ${err.message}`, 'error', 3200);
+      }
+    });
+    document.body.appendChild(input);
+    input.click();
+    window.setTimeout(() => {
+      if (input.parentElement) input.parentElement.removeChild(input);
+    }, 0);
+  }
+
+  async _delete(asset) {
+    if (!asset) return;
+    const confirmed = window.confirm(`Delete ${normalizeName(asset)}? This cannot be undone.`);
+    if (!confirmed) return;
+    await this.service.remove(asset.guid);
+    await this.refresh();
+  }
+
+  _revealAsset(asset) {
+    if (!asset) return;
+    console.info('[Assets] Reveal requested', asset);
+    showToast('Reveal not implemented yet.', 'info', 2200);
+  }
+
+  _setupFloatingImport() {
     if (typeof document === 'undefined') {
       return;
     }

--- a/editor/ui/dropdrag.js
+++ b/editor/ui/dropdrag.js
@@ -1,0 +1,151 @@
+const DRAG_MIME = 'application/x-axisforge-asset';
+const JSON_MIME = 'application/json';
+
+function safeParse(json) {
+  if (!json) return null;
+  try {
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}
+
+function encodePayload(payload) {
+  try {
+    return JSON.stringify(payload);
+  } catch (err) {
+    console.warn('[DropDrag] Failed to encode payload', err);
+    return null;
+  }
+}
+
+function decodeTransfer(event) {
+  const { dataTransfer } = event;
+  if (!dataTransfer) return null;
+  const raw = dataTransfer.getData(DRAG_MIME) || dataTransfer.getData(JSON_MIME) || dataTransfer.getData('text/plain');
+  if (!raw) return null;
+  if (raw.trim().startsWith('{')) {
+    return safeParse(raw);
+  }
+  return { value: raw };
+}
+
+export function registerDragSource(element, getPayload, options = {}) {
+  if (!element) {
+    return () => {};
+  }
+  const resolve = () => {
+    try {
+      return typeof getPayload === 'function' ? getPayload() : getPayload;
+    } catch (err) {
+      console.warn('[DropDrag] Drag payload resolver failed', err);
+      return null;
+    }
+  };
+  const handleDragStart = event => {
+    const payload = resolve();
+    if (!payload) {
+      event.preventDefault();
+      return;
+    }
+    const encoded = encodePayload(payload);
+    if (!encoded) {
+      event.preventDefault();
+      return;
+    }
+    event.dataTransfer.effectAllowed = options.effectAllowed || 'copy';
+    event.dataTransfer.setData(DRAG_MIME, encoded);
+    event.dataTransfer.setData(JSON_MIME, encoded);
+    if (typeof payload.label === 'string') {
+      event.dataTransfer.setData('text/plain', payload.label);
+    }
+    if (options.preview && event.dataTransfer.setDragImage) {
+      const { element: previewEl, offsetX = 0, offsetY = 0 } = options.preview(payload) || {};
+      if (previewEl instanceof Element) {
+        event.dataTransfer.setDragImage(previewEl, offsetX, offsetY);
+      }
+    }
+    if (typeof options.onStart === 'function') {
+      options.onStart(payload, event);
+    }
+  };
+  const handleDragEnd = event => {
+    if (typeof options.onEnd === 'function') {
+      options.onEnd(event);
+    }
+  };
+  element.setAttribute('draggable', 'true');
+  element.addEventListener('dragstart', handleDragStart);
+  element.addEventListener('dragend', handleDragEnd);
+  return () => {
+    element.removeAttribute('draggable');
+    element.removeEventListener('dragstart', handleDragStart);
+    element.removeEventListener('dragend', handleDragEnd);
+  };
+}
+
+export function registerDropTarget(element, { onDrop, onEnter, onLeave, types = null, effect = 'copy' } = {}) {
+  if (!element) {
+    return () => {};
+  }
+  let depth = 0;
+  const accepts = payload => {
+    if (!payload) return false;
+    if (!types || !types.length) return true;
+    const payloadType = payload.type || payload.kind;
+    return types.includes(payloadType);
+  };
+  const handleDragOver = event => {
+    const payload = decodeTransfer(event);
+    if (!accepts(payload)) {
+      return;
+    }
+    event.preventDefault();
+    event.dataTransfer.dropEffect = effect;
+  };
+  const handleDrop = event => {
+    const payload = decodeTransfer(event);
+    depth = 0;
+    element.classList.remove('is-drop-target');
+    if (!accepts(payload)) {
+      return;
+    }
+    event.preventDefault();
+    if (typeof onDrop === 'function') {
+      onDrop(payload, event);
+    }
+  };
+  const handleEnter = event => {
+    const payload = decodeTransfer(event);
+    if (!accepts(payload)) {
+      return;
+    }
+    depth += 1;
+    element.classList.add('is-drop-target');
+    if (typeof onEnter === 'function') {
+      onEnter(payload, event);
+    }
+  };
+  const handleLeave = event => {
+    if (depth > 0) depth -= 1;
+    if (depth === 0) {
+      element.classList.remove('is-drop-target');
+    }
+    if (typeof onLeave === 'function') {
+      onLeave(event);
+    }
+  };
+  element.addEventListener('dragover', handleDragOver);
+  element.addEventListener('drop', handleDrop);
+  element.addEventListener('dragenter', handleEnter);
+  element.addEventListener('dragleave', handleLeave);
+  return () => {
+    element.removeEventListener('dragover', handleDragOver);
+    element.removeEventListener('drop', handleDrop);
+    element.removeEventListener('dragenter', handleEnter);
+    element.removeEventListener('dragleave', handleLeave);
+    element.classList.remove('is-drop-target');
+  };
+}
+
+export default { registerDragSource, registerDropTarget };

--- a/editor/ui/preview/preview.js
+++ b/editor/ui/preview/preview.js
@@ -1,0 +1,219 @@
+const TYPE_LABELS = {
+  textures: 'Texture',
+  materials: 'Material',
+  models: 'Mesh',
+  audio: 'Audio',
+  unknown: 'Unknown',
+};
+
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return '—';
+  }
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value.toFixed(unit === 0 ? 0 : 1)} ${units[unit]}`;
+}
+
+function guessMimeType(name = '') {
+  const ext = name.split('.').pop()?.toLowerCase();
+  switch (ext) {
+    case 'png':
+      return 'image/png';
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg';
+    case 'gif':
+      return 'image/gif';
+    case 'webp':
+      return 'image/webp';
+    case 'ktx':
+    case 'ktx2':
+      return 'image/ktx2';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+function base64ToBlob(base64, mimeType) {
+  try {
+    if (typeof Uint8Array !== 'function') {
+      return null;
+    }
+    const binary = atob(base64);
+    const length = binary.length;
+    const bytes = new Uint8Array(length);
+    for (let i = 0; i < length; i += 1) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return new Blob([bytes], { type: mimeType });
+  } catch (err) {
+    console.warn('[Preview] Failed to decode base64', err);
+    return null;
+  }
+}
+
+function createMetadataRow(label, value) {
+  const row = document.createElement('div');
+  row.className = 'asset-preview__meta-row';
+  const key = document.createElement('span');
+  key.className = 'asset-preview__meta-key';
+  key.textContent = label;
+  const val = document.createElement('span');
+  val.className = 'asset-preview__meta-value';
+  val.textContent = value ?? '—';
+  row.append(key, val);
+  return row;
+}
+
+export default class AssetPreview {
+  constructor() {
+    this.asset = null;
+    this.objectUrl = null;
+    this.imageLoaded = false;
+    this.element = document.createElement('div');
+    this.element.className = 'asset-preview';
+
+    this.thumbnail = document.createElement('div');
+    this.thumbnail.className = 'asset-preview__thumb';
+    this.image = document.createElement('img');
+    this.image.alt = '';
+    this.image.className = 'asset-preview__image';
+    this.thumbnail.appendChild(this.image);
+
+    this.placeholder = document.createElement('div');
+    this.placeholder.className = 'asset-preview__placeholder';
+    this.thumbnail.appendChild(this.placeholder);
+
+    this.meta = document.createElement('div');
+    this.meta.className = 'asset-preview__meta';
+
+    this.element.append(this.thumbnail, this.meta);
+
+    this.image.addEventListener('error', () => {
+      this.thumbnail.classList.add('has-error');
+    });
+    this.image.addEventListener('load', () => {
+      this.imageLoaded = true;
+      this.thumbnail.classList.remove('is-loading');
+      if (this.asset) {
+        this._updateDimensions(this.image.naturalWidth, this.image.naturalHeight);
+      }
+    });
+  }
+
+  dispose() {
+    this._revokeObjectUrl();
+    this.asset = null;
+  }
+
+  setAsset(asset) {
+    this.asset = asset || null;
+    this.imageLoaded = false;
+    this.thumbnail.classList.remove('has-error');
+    this.thumbnail.classList.remove('is-loading');
+    this.placeholder.textContent = '';
+    this._revokeObjectUrl();
+    this.image.src = '';
+    this.meta.textContent = '';
+
+    if (!asset) {
+      this.placeholder.textContent = 'Select an asset to preview';
+      this.thumbnail.classList.add('asset-preview__thumb--empty');
+      return;
+    }
+
+    this.thumbnail.classList.remove('asset-preview__thumb--empty');
+    this.placeholder.textContent = TYPE_LABELS[asset.type] || 'Asset';
+    this.thumbnail.classList.add('is-loading');
+
+    const rows = [];
+    rows.push(createMetadataRow('Name', asset.name || asset.logicalPath || asset.guid || 'Asset'));
+    rows.push(createMetadataRow('Type', TYPE_LABELS[asset.type] || 'Asset'));
+    if (asset.logicalPath) {
+      rows.push(createMetadataRow('Path', asset.logicalPath));
+    }
+    if (asset.size != null) {
+      rows.push(createMetadataRow('Size', formatBytes(asset.size)));
+    }
+    this.meta.replaceChildren(...rows);
+
+    if (asset.type === 'textures') {
+      this._loadTexture(asset);
+    } else {
+      this.thumbnail.classList.remove('is-loading');
+    }
+  }
+
+  _updateDimensions(width, height) {
+    const existing = this.meta.querySelector('[data-meta="dimensions"]');
+    const value = width && height ? `${width} × ${height}` : '—';
+    if (existing) {
+      existing.textContent = value;
+      return;
+    }
+    const row = createMetadataRow('Dimensions', value);
+    row.querySelector('.asset-preview__meta-key').dataset.meta = 'dimensions-label';
+    row.querySelector('.asset-preview__meta-value').dataset.meta = 'dimensions';
+    this.meta.appendChild(row);
+  }
+
+  async _loadTexture(asset) {
+    if (asset.data) {
+      await this._loadFromBase64(asset);
+      return;
+    }
+    if (asset.source?.kind === 'path' && asset.source.value) {
+      this.image.src = asset.source.value;
+      return;
+    }
+    this.thumbnail.classList.remove('is-loading');
+    this.placeholder.textContent = 'No preview available';
+  }
+
+  async _loadFromBase64(asset) {
+    const mime = guessMimeType(asset.name || 'texture.png');
+    let blob = null;
+    if (typeof Blob === 'function' && typeof Uint8Array === 'function') {
+      try {
+        const decoded = typeof atob === 'function' ? base64ToBlob(asset.data, mime) : null;
+        if (decoded) {
+          blob = decoded;
+        }
+      } catch (err) {
+        console.warn('[Preview] Failed to create blob from base64', err);
+      }
+    }
+    if (!blob && typeof Buffer !== 'undefined') {
+      try {
+        const buf = Buffer.from(asset.data, 'base64');
+        blob = new Blob([buf], { type: mime });
+      } catch (err) {
+        console.warn('[Preview] Failed to create blob via Buffer', err);
+      }
+    }
+    if (!blob) {
+      this.thumbnail.classList.remove('is-loading');
+      this.placeholder.textContent = 'No preview available';
+      return;
+    }
+    this.objectUrl = URL.createObjectURL(blob);
+    this.image.src = this.objectUrl;
+  }
+
+  _revokeObjectUrl() {
+    if (this.objectUrl) {
+      try {
+        URL.revokeObjectURL(this.objectUrl);
+      } catch {
+        // ignore
+      }
+      this.objectUrl = null;
+    }
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,7 @@
   <link rel="stylesheet" href="/editor/ui/progress.css" />
   <link rel="stylesheet" href="/editor/panes/explorer.css" />
   <link rel="stylesheet" href="/editor/panes/properties.css" />
+  <link rel="stylesheet" href="/editor/panes/assets.css" />
   <link rel="stylesheet" href="/editor/ui/tree/tree.css" />
 </head>
 <body>


### PR DESCRIPTION
## Summary
- rebuild the Assets pane with grid/list browsing, previews, filtering, and context menus
- add shared drag-and-drop helpers and preview rendering for asset thumbnails
- extend asset/material services and properties pane to support drag-to-assign textures

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4ca64dd68832ca937e251a27a6853