### PR TITLE
Add layout presets management UI

### DIFF
--- a/editor/app/shell.js
+++ b/editor/app/shell.js
@@ -1,59 +1,17 @@
 
 import { DockArea, STORAGE_KEY as LAYOUT_STORAGE_KEY } from '../ui/dock/dock.js';
+import { ROBLOX_LAYOUT } from '../ui/dock/defaultLayout.js';
 import { startPlay, stopPlay } from '../services/playmode.js';
 import { CommandRegistry } from '../ui/commands.js';
 import { Menubar } from '../ui/menubar.js';
 import { HotkeyManager } from '../ui/hotkeys.js';
 import StatusBar from '../ui/statusbar.js';
 import { showToast } from '../ui/toast.js';
+import LayoutPresetsPane from '../panes/layoutPresets.js';
 
 const THEME_STORAGE_KEY = 'axisforge.theme';
 
-export const DEFAULT_LAYOUT = {
-  type: 'split',
-  direction: 'horizontal',
-  sizes: [0.22, 0.78],
-  children: [
-    {
-      type: 'stack',
-      id: 'stack-explorer',
-      tabs: ['explorer', 'assets'],
-      active: 'explorer',
-    },
-    {
-      type: 'split',
-      direction: 'vertical',
-      sizes: [0.68, 0.32],
-      children: [
-        {
-          type: 'stack',
-          id: 'stack-viewport',
-          tabs: ['viewport'],
-          active: 'viewport',
-        },
-        {
-          type: 'split',
-          direction: 'horizontal',
-          sizes: [0.5, 0.5],
-          children: [
-            {
-              type: 'stack',
-              id: 'stack-console',
-              tabs: ['console'],
-              active: 'console',
-            },
-            {
-              type: 'stack',
-              id: 'stack-properties',
-              tabs: ['properties'],
-              active: 'properties',
-            },
-          ],
-        },
-      ],
-    },
-  ],
-};
+export const DEFAULT_LAYOUT = ROBLOX_LAYOUT;
 
 function countPanes(node) {
   if (!node) return 0;
@@ -114,6 +72,24 @@ export class EditorShell {
       this._setStatus('Layout saved', 'positive', 1200);
       this._syncViewCommands();
     };
+
+    this.layoutPresets = new LayoutPresetsPane({
+      dock: this.dock,
+      onLayoutApplied: () => {
+        this._syncViewCommands();
+        this._updateLayoutInfo();
+      },
+      onPresetSaved: () => {
+        this._updateLayoutInfo();
+      },
+      onPresetDeleted: () => {
+        this._updateLayoutInfo();
+      },
+      onReset: () => {
+        this._syncViewCommands();
+        this._updateLayoutInfo();
+      },
+    });
 
     this._registerShellCommands();
 
@@ -278,6 +254,15 @@ export class EditorShell {
         this._setStatus('Layout reset', 'positive', 1600);
         this._syncViewCommands();
         this._updateLayoutInfo();
+      },
+    });
+    this.commands.registerCommand({
+      id: 'view.manageLayouts',
+      title: 'Layout Presets…',
+      menu: 'view',
+      order: 100,
+      run: () => {
+        this.layoutPresets?.open?.();
       },
     });
 

--- a/editor/panes/layoutPresets.css
+++ b/editor/panes/layoutPresets.css
@@ -1,0 +1,192 @@
+.layout-presets {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.layout-presets[hidden] {
+  display: none;
+}
+
+.layout-presets__dialog {
+  background: var(--panel-bg, #1e1f26);
+  color: var(--panel-fg, #f5f6f8);
+  min-width: 320px;
+  max-width: min(480px, 90vw);
+  border-radius: 8px;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.layout-presets__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 18px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.layout-presets__close {
+  appearance: none;
+  border: none;
+  background: none;
+  color: inherit;
+  font-size: 18px;
+  cursor: pointer;
+  line-height: 1;
+  padding: 4px;
+}
+
+.layout-presets__body {
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.layout-presets__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 220px;
+  overflow-y: auto;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.25);
+}
+
+.layout-presets__item {
+  width: 100%;
+  border: none;
+  background: none;
+  color: inherit;
+  padding: 10px 14px;
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 14px;
+}
+
+.layout-presets__item span {
+  flex: 1;
+}
+
+.layout-presets__item[data-selected="true"] {
+  background: rgba(88, 136, 255, 0.18);
+}
+
+.layout-presets__item[data-builtin="true"] {
+  opacity: 0.8;
+}
+
+.layout-presets__empty {
+  padding: 20px;
+  text-align: center;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.layout-presets__buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.layout-presets__buttons button {
+  flex: 1 1 45%;
+  min-width: 120px;
+  padding: 10px 12px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
+  color: inherit;
+  cursor: pointer;
+  font-size: 13px;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.layout-presets__buttons button:hover:not(:disabled) {
+  background: rgba(88, 136, 255, 0.2);
+  border-color: rgba(88, 136, 255, 0.45);
+}
+
+.layout-presets__buttons button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.layout-presets__modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1010;
+}
+
+.layout-presets__modal[hidden] {
+  display: none;
+}
+
+.layout-presets__modal-content {
+  background: var(--panel-bg, #1e1f26);
+  color: var(--panel-fg, #f5f6f8);
+  width: min(520px, 90vw);
+  border-radius: 8px;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  padding: 18px;
+  gap: 12px;
+}
+
+.layout-presets__modal textarea {
+  width: 100%;
+  min-height: 180px;
+  resize: vertical;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(0, 0, 0, 0.3);
+  color: inherit;
+  font-family: var(--font-mono, 'Fira Code', monospace);
+  font-size: 12px;
+  padding: 10px;
+}
+
+.layout-presets__modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.layout-presets__modal-actions button {
+  padding: 8px 14px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
+  color: inherit;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.layout-presets__modal-actions button:hover:not(:disabled) {
+  background: rgba(88, 136, 255, 0.2);
+  border-color: rgba(88, 136, 255, 0.45);
+}
+
+.layout-presets__modal-actions button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}

--- a/editor/panes/layoutPresets.js
+++ b/editor/panes/layoutPresets.js
@@ -1,0 +1,543 @@
+import { PRESET_STORAGE_KEY } from '../ui/dock/dock.js';
+import { ROBLOX_LAYOUT } from '../ui/dock/defaultLayout.js';
+import { showToast } from '../ui/toast.js';
+
+function cloneLayout(layout) {
+  if (!layout) return null;
+  if (typeof structuredClone === 'function') {
+    try {
+      return structuredClone(layout);
+    } catch (err) {
+      // fall through to JSON clone
+    }
+  }
+  try {
+    return JSON.parse(JSON.stringify(layout));
+  } catch (err) {
+    console.warn('[LayoutPresets] Failed to clone layout', err);
+    return null;
+  }
+}
+
+function isPlainObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+export default class LayoutPresetsPane {
+  constructor({ dock, onLayoutApplied, onPresetSaved, onPresetDeleted, onReset } = {}) {
+    this.dock = dock;
+    this.onLayoutApplied = typeof onLayoutApplied === 'function' ? onLayoutApplied : null;
+    this.onPresetSaved = typeof onPresetSaved === 'function' ? onPresetSaved : null;
+    this.onPresetDeleted = typeof onPresetDeleted === 'function' ? onPresetDeleted : null;
+    this.onReset = typeof onReset === 'function' ? onReset : null;
+
+    this.builtinPresets = [
+      { name: 'Roblox', layout: cloneLayout(ROBLOX_LAYOUT) },
+    ];
+    this.userPresets = new Map();
+    this.selectedPreset = null;
+    this.modalMode = null;
+
+    this._createUI();
+    this._loadPresets();
+    this._renderList();
+  }
+
+  open() {
+    this._loadPresets();
+    this._renderList();
+    this.root.hidden = false;
+    this.root.setAttribute('aria-hidden', 'false');
+    this.dialog.focus();
+    window.addEventListener('keydown', this._handleKeyDown, { passive: false });
+  }
+
+  close() {
+    this.root.hidden = true;
+    this.root.setAttribute('aria-hidden', 'true');
+    window.removeEventListener('keydown', this._handleKeyDown);
+  }
+
+  _createUI() {
+    this.root = document.createElement('div');
+    this.root.className = 'layout-presets';
+    this.root.hidden = true;
+    this.root.setAttribute('role', 'dialog');
+    this.root.setAttribute('aria-modal', 'true');
+    this.root.setAttribute('aria-hidden', 'true');
+
+    this.dialog = document.createElement('div');
+    this.dialog.className = 'layout-presets__dialog';
+    this.dialog.tabIndex = -1;
+
+    const header = document.createElement('div');
+    header.className = 'layout-presets__header';
+    header.textContent = 'Layout Presets';
+
+    const closeButton = document.createElement('button');
+    closeButton.type = 'button';
+    closeButton.className = 'layout-presets__close';
+    closeButton.setAttribute('aria-label', 'Close');
+    closeButton.innerHTML = '&times;';
+    closeButton.addEventListener('click', () => this.close());
+    header.appendChild(closeButton);
+
+    const body = document.createElement('div');
+    body.className = 'layout-presets__body';
+
+    this.list = document.createElement('ul');
+    this.list.className = 'layout-presets__list';
+    this.list.setAttribute('role', 'listbox');
+
+    body.appendChild(this.list);
+
+    this.buttons = document.createElement('div');
+    this.buttons.className = 'layout-presets__buttons';
+
+    this.saveButton = this._createButton('Save Current as…', () => this._handleSaveCurrent());
+    this.applyButton = this._createButton('Apply', () => this._handleApply());
+    this.renameButton = this._createButton('Rename', () => this._handleRename());
+    this.deleteButton = this._createButton('Delete', () => this._handleDelete());
+    this.resetButton = this._createButton('Reset to Default', () => this._handleReset());
+    this.exportButton = this._createButton('Export', () => this._handleExport());
+    this.importButton = this._createButton('Import', () => this._handleImport());
+
+    this.buttons.append(
+      this.saveButton,
+      this.applyButton,
+      this.renameButton,
+      this.deleteButton,
+      this.resetButton,
+      this.exportButton,
+      this.importButton,
+    );
+
+    body.appendChild(this.buttons);
+
+    this.dialog.append(header, body);
+    this.root.appendChild(this.dialog);
+
+    this.modal = document.createElement('div');
+    this.modal.className = 'layout-presets__modal';
+    this.modal.hidden = true;
+
+    const modalContent = document.createElement('div');
+    modalContent.className = 'layout-presets__modal-content';
+
+    this.modalMessage = document.createElement('div');
+    modalContent.appendChild(this.modalMessage);
+
+    this.modalTextarea = document.createElement('textarea');
+    modalContent.appendChild(this.modalTextarea);
+
+    const modalActions = document.createElement('div');
+    modalActions.className = 'layout-presets__modal-actions';
+
+    this.modalCancel = document.createElement('button');
+    this.modalCancel.type = 'button';
+    this.modalCancel.textContent = 'Cancel';
+    this.modalCancel.addEventListener('click', () => this._closeModal());
+
+    this.modalConfirm = document.createElement('button');
+    this.modalConfirm.type = 'button';
+    this.modalConfirm.textContent = 'Import';
+    this.modalConfirm.addEventListener('click', () => this._confirmModal());
+
+    modalActions.append(this.modalCancel, this.modalConfirm);
+    modalContent.appendChild(modalActions);
+    this.modal.appendChild(modalContent);
+
+    this.modal.addEventListener('click', event => {
+      if (event.target === this.modal) {
+        this._closeModal();
+      }
+    });
+
+    document.body.append(this.root, this.modal);
+
+    this._handleKeyDown = event => {
+      if (event.key === 'Escape') {
+        if (!this.modal.hidden) {
+          this._closeModal();
+          event.preventDefault();
+        } else if (!this.root.hidden) {
+          this.close();
+          event.preventDefault();
+        }
+      }
+    };
+  }
+
+  _createButton(label, handler) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = label;
+    button.addEventListener('click', handler);
+    return button;
+  }
+
+  _isBuiltin(name) {
+    return this.builtinPresets.some(preset => preset.name === name);
+  }
+
+  _getAllPresets() {
+    const items = [];
+    for (const preset of this.builtinPresets) {
+      items.push({ ...preset, builtin: true });
+    }
+    for (const [name, layout] of this.userPresets.entries()) {
+      items.push({ name, layout, builtin: false });
+    }
+    return items;
+  }
+
+  _getPresetByName(name) {
+    if (!name) return null;
+    const builtin = this.builtinPresets.find(preset => preset.name === name);
+    if (builtin) {
+      return { name: builtin.name, layout: cloneLayout(builtin.layout), builtin: true };
+    }
+    if (this.userPresets.has(name)) {
+      return { name, layout: cloneLayout(this.userPresets.get(name)), builtin: false };
+    }
+    return null;
+  }
+
+  _loadPresets() {
+    this.userPresets.clear();
+    if (typeof localStorage === 'undefined') {
+      return;
+    }
+    try {
+      const raw = localStorage.getItem(PRESET_STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw);
+      if (!isPlainObject(parsed)) return;
+      for (const [name, layout] of Object.entries(parsed)) {
+        if (!name || !isPlainObject(layout)) {
+          continue;
+        }
+        if (this._isBuiltin(name)) {
+          continue;
+        }
+        const cloned = cloneLayout(layout);
+        if (cloned) {
+          this.userPresets.set(name, cloned);
+        }
+      }
+    } catch (err) {
+      console.warn('[LayoutPresets] Failed to load presets', err);
+    }
+  }
+
+  _savePresets() {
+    if (typeof localStorage === 'undefined') {
+      return;
+    }
+    try {
+      const data = {};
+      for (const [name, layout] of this.userPresets.entries()) {
+        data[name] = cloneLayout(layout) || layout;
+      }
+      localStorage.setItem(PRESET_STORAGE_KEY, JSON.stringify(data));
+    } catch (err) {
+      console.warn('[LayoutPresets] Failed to save presets', err);
+      showToast('Unable to save presets', 'error', 1600);
+    }
+  }
+
+  _renderList() {
+    this.list.innerHTML = '';
+    const presets = this._getAllPresets();
+    if (!presets.length) {
+      const empty = document.createElement('div');
+      empty.className = 'layout-presets__empty';
+      empty.textContent = 'No presets saved yet.';
+      this.list.appendChild(empty);
+      this.selectedPreset = null;
+      this._updateButtons();
+      return;
+    }
+
+    if (!this.selectedPreset || !presets.some(item => item.name === this.selectedPreset)) {
+      const defaultPreset = presets[0];
+      this.selectedPreset = defaultPreset?.name || null;
+    }
+
+    for (const preset of presets) {
+      const item = document.createElement('li');
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'layout-presets__item';
+      button.dataset.preset = preset.name;
+      button.dataset.selected = preset.name === this.selectedPreset ? 'true' : 'false';
+      button.dataset.builtin = preset.builtin ? 'true' : 'false';
+
+      const nameLabel = document.createElement('span');
+      nameLabel.textContent = preset.name;
+      button.appendChild(nameLabel);
+
+      if (preset.builtin) {
+        const badge = document.createElement('span');
+        badge.textContent = 'Default';
+        badge.style.fontSize = '11px';
+        badge.style.opacity = '0.75';
+        button.appendChild(badge);
+      }
+
+      button.addEventListener('click', () => {
+        this._selectPreset(preset.name, true);
+      });
+      button.addEventListener('dblclick', () => {
+        this._selectPreset(preset.name, false);
+        this._handleApply();
+      });
+
+      item.appendChild(button);
+      this.list.appendChild(item);
+    }
+
+    this._updateButtons();
+  }
+
+  _selectPreset(name, focus = false) {
+    this.selectedPreset = name;
+    for (const button of this.list.querySelectorAll('.layout-presets__item')) {
+      button.dataset.selected = button.dataset.preset === name ? 'true' : 'false';
+    }
+    this._updateButtons();
+    if (focus) {
+      const target = this.list.querySelector(`.layout-presets__item[data-preset="${CSS.escape(name)}"]`);
+      target?.focus?.();
+    }
+  }
+
+  _updateButtons() {
+    const hasSelection = Boolean(this.selectedPreset);
+    this.applyButton.disabled = !hasSelection;
+    const isBuiltin = hasSelection && this._isBuiltin(this.selectedPreset);
+    this.renameButton.disabled = !hasSelection || isBuiltin;
+    this.deleteButton.disabled = !hasSelection || isBuiltin;
+  }
+
+  _handleSaveCurrent() {
+    if (!this.dock) return;
+    const layout = this.dock.serializeLayout();
+    if (!layout) {
+      showToast('No layout available to save', 'warn', 1600);
+      return;
+    }
+    const name = window.prompt('Preset name');
+    if (!name) {
+      return;
+    }
+    const trimmed = name.trim();
+    if (!trimmed) {
+      return;
+    }
+    if (this._isBuiltin(trimmed)) {
+      showToast('Cannot overwrite the default preset', 'warn', 1600);
+      return;
+    }
+    if (this.userPresets.has(trimmed)) {
+      const overwrite = window.confirm(`Overwrite preset "${trimmed}"?`);
+      if (!overwrite) {
+        return;
+      }
+    }
+    this.userPresets.set(trimmed, layout);
+    this._savePresets();
+    this._renderList();
+    this._selectPreset(trimmed);
+    showToast(`Saved layout "${trimmed}"`, 'success', 1600);
+    if (this.onPresetSaved) {
+      this.onPresetSaved(trimmed);
+    }
+  }
+
+  _handleApply() {
+    if (!this.dock || !this.selectedPreset) {
+      return;
+    }
+    const preset = this._getPresetByName(this.selectedPreset);
+    if (!preset || !preset.layout) {
+      showToast('Preset is invalid', 'error', 1600);
+      return;
+    }
+    const applied = this.dock.deserializeLayout(preset.layout);
+    if (!applied) {
+      showToast('Unable to apply preset', 'error', 1600);
+      return;
+    }
+    this.close();
+    if (this.onLayoutApplied) {
+      this.onLayoutApplied(preset.name, preset.builtin);
+    }
+  }
+
+  _handleRename() {
+    if (!this.selectedPreset || this._isBuiltin(this.selectedPreset)) {
+      return;
+    }
+    const currentName = this.selectedPreset;
+    const newName = window.prompt('Rename preset', currentName);
+    if (!newName) {
+      return;
+    }
+    const trimmed = newName.trim();
+    if (!trimmed || trimmed === currentName) {
+      return;
+    }
+    if (this._isBuiltin(trimmed)) {
+      showToast('Name reserved for default presets', 'warn', 1600);
+      return;
+    }
+    const layout = this.userPresets.get(currentName);
+    this.userPresets.delete(currentName);
+    this.userPresets.set(trimmed, layout);
+    this._savePresets();
+    this._renderList();
+    this._selectPreset(trimmed);
+    showToast(`Renamed preset to "${trimmed}"`, 'success', 1600);
+    if (this.onPresetSaved) {
+      this.onPresetSaved(trimmed);
+    }
+  }
+
+  _handleDelete() {
+    if (!this.selectedPreset || this._isBuiltin(this.selectedPreset)) {
+      return;
+    }
+    const confirmed = window.confirm(`Delete preset "${this.selectedPreset}"?`);
+    if (!confirmed) {
+      return;
+    }
+    const name = this.selectedPreset;
+    this.userPresets.delete(name);
+    this._savePresets();
+    this.selectedPreset = null;
+    this._renderList();
+    showToast(`Deleted preset "${name}"`, 'info', 1400);
+    if (this.onPresetDeleted) {
+      this.onPresetDeleted(name);
+    }
+  }
+
+  _handleReset() {
+    if (!this.dock) return;
+    this.dock.resetToDefault();
+    this.close();
+    showToast('Layout reset to default', 'success', 1600);
+    if (this.onReset) {
+      this.onReset();
+    }
+  }
+
+  _handleExport() {
+    const presets = {};
+    for (const preset of this.builtinPresets) {
+      presets[preset.name] = cloneLayout(preset.layout) || preset.layout;
+    }
+    for (const [name, layout] of this.userPresets.entries()) {
+      presets[name] = cloneLayout(layout) || layout;
+    }
+    const payload = { version: 1, presets };
+    const json = JSON.stringify(payload, null, 2);
+    this._openModal({
+      mode: 'export',
+      title: 'Export Layout Presets',
+      confirmLabel: 'Close',
+      editable: false,
+      value: json,
+    });
+    if (typeof navigator?.clipboard?.writeText === 'function') {
+      navigator.clipboard.writeText(json).catch(() => {});
+    }
+  }
+
+  _handleImport() {
+    this._openModal({
+      mode: 'import',
+      title: 'Import Layout Presets',
+      confirmLabel: 'Import',
+      editable: true,
+      value: '',
+    });
+  }
+
+  _openModal({ mode, title, confirmLabel, editable, value }) {
+    this.modalMode = mode;
+    this.modalMessage.textContent = title || '';
+    this.modalTextarea.value = value || '';
+    this.modalTextarea.readOnly = !editable;
+    this.modalTextarea.placeholder = editable ? '{ "presets": { "My Layout": { … } } }' : '';
+    this.modalConfirm.textContent = confirmLabel || 'OK';
+    this.modal.hidden = false;
+    this.modalTextarea.focus();
+    this.modalTextarea.select();
+    window.addEventListener('keydown', this._handleKeyDown, { passive: false });
+  }
+
+  _closeModal() {
+    this.modal.hidden = true;
+    this.modalMode = null;
+    this.modalTextarea.value = '';
+    this.modalTextarea.readOnly = false;
+    window.removeEventListener('keydown', this._handleKeyDown);
+  }
+
+  _confirmModal() {
+    if (this.modalMode === 'export') {
+      this._closeModal();
+      return;
+    }
+    if (this.modalMode === 'import') {
+      const raw = this.modalTextarea.value;
+      if (!raw) {
+        showToast('Paste JSON to import presets', 'warn', 1600);
+        return;
+      }
+      try {
+        const parsed = JSON.parse(raw);
+        const incoming = this._extractPresets(parsed);
+        if (!incoming.size) {
+          showToast('No presets found in JSON', 'warn', 1600);
+          return;
+        }
+        for (const [name, layout] of incoming.entries()) {
+          this.userPresets.set(name, layout);
+        }
+        this._savePresets();
+        this._renderList();
+        this._closeModal();
+        showToast(`Imported ${incoming.size} preset${incoming.size === 1 ? '' : 's'}`, 'success', 1600);
+      } catch (err) {
+        console.warn('[LayoutPresets] Failed to import presets', err);
+        showToast('Invalid JSON, unable to import presets', 'error', 1800);
+      }
+      return;
+    }
+    this._closeModal();
+  }
+
+  _extractPresets(data) {
+    const map = new Map();
+    if (!data || typeof data !== 'object') {
+      return map;
+    }
+    const source = isPlainObject(data.presets) ? data.presets : data;
+    for (const [name, layout] of Object.entries(source)) {
+      if (!name || !isPlainObject(layout)) {
+        continue;
+      }
+      if (this._isBuiltin(name)) {
+        continue;
+      }
+      const cloned = cloneLayout(layout);
+      if (cloned) {
+        map.set(name, cloned);
+      }
+    }
+    return map;
+  }
+}

--- a/editor/ui/dock/defaultLayout.js
+++ b/editor/ui/dock/defaultLayout.js
@@ -1,0 +1,58 @@
+export const ROBLOX_LAYOUT = {
+  type: 'split',
+  direction: 'horizontal',
+  sizes: [0.22, 0.78],
+  children: [
+    {
+      type: 'stack',
+      id: 'stack-explorer',
+      tabs: ['explorer'],
+      active: 'explorer',
+    },
+    {
+      type: 'split',
+      direction: 'horizontal',
+      sizes: [0.7, 0.3],
+      children: [
+        {
+          type: 'split',
+          direction: 'vertical',
+          sizes: [0.65, 0.35],
+          children: [
+            {
+              type: 'stack',
+              id: 'stack-viewport',
+              tabs: ['viewport'],
+              active: 'viewport',
+            },
+            {
+              type: 'split',
+              direction: 'horizontal',
+              sizes: [0.6, 0.4],
+              children: [
+                {
+                  type: 'stack',
+                  id: 'stack-console',
+                  tabs: ['console'],
+                  active: 'console',
+                },
+                {
+                  type: 'stack',
+                  id: 'stack-assets',
+                  tabs: ['assets'],
+                  active: 'assets',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'stack',
+          id: 'stack-properties',
+          tabs: ['properties'],
+          active: 'properties',
+        },
+      ],
+    },
+  ],
+};

--- a/editor/ui/dock/dock.js
+++ b/editor/ui/dock/dock.js
@@ -1,5 +1,6 @@
 
 const STORAGE_KEY = 'axisforge.layout.v1';
+export const PRESET_STORAGE_KEY = 'axisforge.layout.presets.v1';
 let stackIdCounter = 0;
 
 function generateStackId() {
@@ -395,6 +396,28 @@ export class DockArea {
     }
   }
 
+  serializeLayout() {
+    return this.layout ? cloneLayout(this.layout) : null;
+  }
+
+  deserializeLayout(layout, { save = true } = {}) {
+    if (!layout) return false;
+    const cloned = cloneLayout(layout);
+    const pruned = pruneLayout(cloned, this.panes);
+    const normalized = normalizeLayout(pruned);
+    if (!normalized) return false;
+    this.layout = normalized;
+    this.render();
+    if (save) {
+      this.persistLayout();
+    }
+    return true;
+  }
+
+  getDefaultLayout() {
+    return this.defaultLayout ? cloneLayout(this.defaultLayout) : null;
+  }
+
   updateLayout(updater, { save = true } = {}) {
     const next = normalizeLayout(updater(this.layout));
     if (!next) return;
@@ -433,9 +456,7 @@ export class DockArea {
 
   resetToDefault() {
     if (!this.defaultLayout) return;
-    this.layout = cloneLayout(this.defaultLayout);
-    this.render();
-    this.persistLayout();
+    this.deserializeLayout(this.defaultLayout, { save: true });
   }
 
   isPaneVisible(paneId) {

--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,7 @@
   <link rel="stylesheet" href="/editor/panes/explorer.css" />
   <link rel="stylesheet" href="/editor/panes/properties.css" />
   <link rel="stylesheet" href="/editor/panes/assets.css" />
+  <link rel="stylesheet" href="/editor/panes/layoutPresets.css" />
   <link rel="stylesheet" href="/editor/ui/tree/tree.css" />
 </head>
 <body>


### PR DESCRIPTION
## Summary
- replace the default Roblox-inspired dock layout and expose it from a shared module
- extend DockArea with serialization helpers and preset storage key
- add a layout preset management dialog with save/apply/rename/delete/export/import actions and styles
- register a View menu command to open the new layout presets UI and include its stylesheet in the shell

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4d2abd1ec832c84dd73818688ba88