### PR TITLE
Add command palette for commands, scene nodes, and assets

### DIFF
--- a/editor/app/main.js
+++ b/editor/app/main.js
@@ -10,6 +10,7 @@ import { Selection } from '../services/selection.js';
 import TransformGizmos from '../components/gizmos.js';
 import { EditorShell, DEFAULT_LAYOUT } from './shell.js';
 import { createViewportOverlay } from '../ui/viewportOverlay.js';
+import CommandPalette from '../ui/palette.js';
 
 function createPanel(title, description) {
   const container = document.createElement('div');
@@ -389,6 +390,14 @@ export function bootstrap() {
   const properties = new Properties(undo, selection);
   const consolePane = new ConsolePane();
   const assetsPane = new AssetsPane(undefined, { floatingUI: false });
+
+  const palette = new CommandPalette({
+    registry: commands,
+    explorer,
+    assets: assetsPane,
+    shell,
+  });
+  shell.setCommandPalette(palette);
 
   const viewportPane = document.createElement('div');
   viewportPane.className = 'viewport-pane';

--- a/editor/app/shell.js
+++ b/editor/app/shell.js
@@ -45,6 +45,7 @@ export class EditorShell {
     this.settingsActive = false;
     this.toolMode = 'select';
     this.gridSnap = { enabled: false, size: 1, unit: 'm' };
+    this.palette = null;
 
     this.root = document.createElement('div');
     this.root.className = 'editor-shell';
@@ -109,6 +110,10 @@ export class EditorShell {
     this.dock.registerPane(pane);
   }
 
+  setCommandPalette(palette) {
+    this.palette = palette || null;
+  }
+
   initializeLayout(layout = DEFAULT_LAYOUT) {
     this.dock.initialize(layout ?? DEFAULT_LAYOUT);
     this._updateLayoutInfo();
@@ -139,6 +144,20 @@ export class EditorShell {
 
   _registerShellCommands() {
     if (!this.commands) return;
+
+    this.commands.registerCommand({
+      id: 'view.commandPalette',
+      title: 'Command Palette…',
+      menu: 'view',
+      order: 5,
+      shortcut: ['Mod+K'],
+      allowInInputs: true,
+      run: () => {
+        if (this.palette?.open) {
+          this.palette.open();
+        }
+      },
+    });
 
     // File menu
     this.commands.registerCommand({

--- a/editor/ui/palette.css
+++ b/editor/ui/palette.css
@@ -1,0 +1,133 @@
+.command-palette {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 8vh 16px 24px;
+  background: rgba(8, 12, 20, 0.55);
+  backdrop-filter: blur(10px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition-fast, 160ms ease);
+  z-index: 2400;
+}
+
+.command-palette.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.command-palette__panel {
+  width: min(640px, 100%);
+  background: var(--panel, #1a2432);
+  border: 1px solid var(--outline, rgba(255, 255, 255, 0.08));
+  border-radius: var(--radius-lg, 0.875rem);
+  box-shadow: var(--shadow-elevated, 0 26px 60px rgba(6, 10, 20, 0.55));
+  display: flex;
+  flex-direction: column;
+  max-height: calc(84vh);
+  overflow: hidden;
+}
+
+.command-palette__input {
+  border: none;
+  padding: 16px 18px;
+  font-size: 1rem;
+  background: transparent;
+  color: var(--text, #f5f7fb);
+  border-bottom: 1px solid var(--divider, rgba(255, 255, 255, 0.08));
+}
+
+.command-palette__input::placeholder {
+  color: var(--text-muted, rgba(244, 246, 251, 0.62));
+}
+
+.command-palette__results {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 8px 0;
+}
+
+.command-palette__empty {
+  padding: 32px 20px;
+  color: var(--text-muted, rgba(244, 246, 251, 0.62));
+  text-align: center;
+}
+
+.command-palette__section {
+  padding: 6px 20px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted, rgba(244, 246, 251, 0.62));
+}
+
+.command-palette__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 20px;
+  cursor: pointer;
+  transition: background var(--transition-fast, 120ms ease), transform var(--transition-fast, 120ms ease);
+}
+
+.command-palette__item:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.command-palette__item.is-active {
+  background: rgba(91, 139, 255, 0.18);
+}
+
+.command-palette__item.is-disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.command-palette__item-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.command-palette__item-label {
+  font-size: 0.98rem;
+  font-weight: 600;
+  color: var(--text, #f5f7fb);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.command-palette__item-label mark,
+.command-palette__item-subtitle mark {
+  background: transparent;
+  color: var(--accent-strong, #82a8ff);
+}
+
+.command-palette__item-subtitle {
+  font-size: 0.8rem;
+  color: var(--text-muted, rgba(244, 246, 251, 0.62));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.command-palette__item-meta {
+  flex: 0 0 auto;
+  font-size: 0.78rem;
+  color: var(--text-muted, rgba(244, 246, 251, 0.62));
+  text-align: right;
+  white-space: nowrap;
+}
+
+@media (max-width: 640px) {
+  .command-palette__panel {
+    width: 100%;
+  }
+}

--- a/editor/ui/palette.js
+++ b/editor/ui/palette.js
@@ -1,0 +1,463 @@
+import { formatShortcut } from './hotkeys.js';
+
+const TYPE_CONFIG = {
+  command: { label: 'Commands', weight: 220 },
+  node: { label: 'Nodes', weight: 140 },
+  asset: { label: 'Assets', weight: 120 },
+};
+
+function escapeHtml(text = '') {
+  return String(text)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function highlightMatch(text, query) {
+  if (!query) {
+    return escapeHtml(text);
+  }
+  const lower = String(text).toLowerCase();
+  const needle = query.toLowerCase();
+  const index = lower.indexOf(needle);
+  if (index === -1) {
+    return escapeHtml(text);
+  }
+  const before = text.slice(0, index);
+  const match = text.slice(index, index + query.length);
+  const after = text.slice(index + query.length);
+  return `${escapeHtml(before)}<mark>${escapeHtml(match)}</mark>${escapeHtml(after)}`;
+}
+
+function computeFuzzyScore(query, target) {
+  if (!query) {
+    return 0;
+  }
+  const haystack = target.toLowerCase();
+  const needle = query.toLowerCase();
+  let score = 0;
+  let lastIndex = -1;
+  for (let i = 0; i < needle.length; i += 1) {
+    const char = needle[i];
+    const index = haystack.indexOf(char, lastIndex + 1);
+    if (index === -1) {
+      return null;
+    }
+    if (index === lastIndex + 1) {
+      score += 8;
+    } else {
+      score += Math.max(1, 6 - (index - lastIndex));
+    }
+    score -= index * 0.05;
+    lastIndex = index;
+  }
+  score -= Math.max(0, haystack.length - needle.length) * 0.02;
+  return score;
+}
+
+function buildNodePath(node) {
+  const parts = [];
+  let current = node?.Parent ?? null;
+  let safety = 0;
+  while (current && safety < 64) {
+    const label = current.Name ?? current.ClassName ?? 'Instance';
+    parts.push(label);
+    current = current.Parent ?? null;
+    safety += 1;
+  }
+  return parts.reverse().join(' / ');
+}
+
+function normalizeAssetName(asset) {
+  return asset?.name || asset?.logicalPath || asset?.guid || 'Asset';
+}
+
+export default class CommandPalette {
+  constructor({ registry = null, explorer = null, assets = null, shell = null } = {}) {
+    this.registry = registry;
+    this.explorer = explorer;
+    this.assets = assets;
+    this.shell = shell;
+
+    this.items = [];
+    this.visibleItems = [];
+    this.activeIndex = 0;
+    this.query = '';
+    this.isOpen = false;
+
+    this._registryUnsubscribe = null;
+
+    this._buildUI();
+
+    if (this.registry?.subscribe) {
+      this._registryUnsubscribe = this.registry.subscribe(() => {
+        if (this.isOpen) {
+          this._rebuildIndex();
+          this._filter();
+        }
+      });
+    }
+  }
+
+  dispose() {
+    if (this._registryUnsubscribe) {
+      this._registryUnsubscribe();
+      this._registryUnsubscribe = null;
+    }
+    if (this.container && this.container.parentElement) {
+      this.container.parentElement.removeChild(this.container);
+    }
+  }
+
+  setExplorer(explorer) {
+    this.explorer = explorer;
+  }
+
+  setAssets(assets) {
+    this.assets = assets;
+  }
+
+  setShell(shell) {
+    this.shell = shell;
+  }
+
+  open() {
+    if (this.isOpen) return;
+    this.isOpen = true;
+    this._rebuildIndex();
+    this.query = '';
+    this.input.value = '';
+    this.activeIndex = 0;
+    this._filter();
+    this.container.classList.add('is-visible');
+    window.requestAnimationFrame(() => {
+      this.input.focus({ preventScroll: true });
+      this.input.select();
+    });
+  }
+
+  close() {
+    if (!this.isOpen) return;
+    this.isOpen = false;
+    this.container.classList.remove('is-visible');
+    this.visibleItems = [];
+    this._renderResults();
+  }
+
+  _buildUI() {
+    this.container = document.createElement('div');
+    this.container.className = 'command-palette';
+
+    this.panel = document.createElement('div');
+    this.panel.className = 'command-palette__panel';
+
+    this.input = document.createElement('input');
+    this.input.type = 'search';
+    this.input.className = 'command-palette__input';
+    this.input.placeholder = 'Search commands, nodes, and assets…';
+
+    this.results = document.createElement('div');
+    this.results.className = 'command-palette__results';
+
+    this.empty = document.createElement('div');
+    this.empty.className = 'command-palette__empty';
+    this.empty.textContent = 'No results';
+
+    this.panel.append(this.input, this.results, this.empty);
+    this.container.appendChild(this.panel);
+    document.body.appendChild(this.container);
+
+    this.container.addEventListener('pointerdown', event => {
+      if (event.target === this.container) {
+        this.close();
+      }
+    });
+
+    this.input.addEventListener('input', () => {
+      this.query = this.input.value.trim();
+      this._filter();
+    });
+
+    this.input.addEventListener('keydown', event => {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        this._moveSelection(1);
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        this._moveSelection(-1);
+      } else if (event.key === 'Home') {
+        event.preventDefault();
+        this._moveSelection('start');
+      } else if (event.key === 'End') {
+        event.preventDefault();
+        this._moveSelection('end');
+      } else if (event.key === 'Enter') {
+        event.preventDefault();
+        this._activate({ openContextMenu: event.shiftKey });
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        this.close();
+      }
+    });
+
+    this.results.addEventListener('pointermove', event => {
+      const item = event.target.closest('.command-palette__item');
+      if (!item) return;
+      const index = Number(item.dataset.index ?? '-1');
+      if (Number.isFinite(index) && index !== this.activeIndex) {
+        this.activeIndex = index;
+        this._highlightActive();
+      }
+    });
+
+    this.results.addEventListener('mousedown', event => {
+      event.preventDefault();
+    });
+
+    this.results.addEventListener('click', event => {
+      const item = event.target.closest('.command-palette__item');
+      if (!item) return;
+      const index = Number(item.dataset.index ?? '-1');
+      if (!Number.isFinite(index) || index < 0 || index >= this.visibleItems.length) {
+        return;
+      }
+      this.activeIndex = index;
+      this._highlightActive();
+      this._activate({ openContextMenu: event.shiftKey });
+    });
+  }
+
+  _rebuildIndex() {
+    this.items = [];
+    if (this.registry) {
+      this.items.push(...this._collectCommands());
+    }
+    if (this.explorer) {
+      this.items.push(...this._collectNodes());
+    }
+    if (this.assets) {
+      this.items.push(...this._collectAssets());
+    }
+  }
+
+  _collectCommands() {
+    if (!this.registry) return [];
+    const items = [];
+    const menus = this.registry.getMenus?.() ?? [];
+    const menuTitles = new Map();
+    for (const menu of menus) {
+      menuTitles.set(menu.id, menu.title);
+    }
+    const appendCommands = (commandList, menuId = null) => {
+      for (const command of commandList) {
+        if (!command || command.type !== 'command') continue;
+        const shortcuts = Array.isArray(command.shortcuts) ? command.shortcuts : [];
+        const shortcut = shortcuts.length ? formatShortcut(shortcuts[0]) : '';
+        const menuTitle = command.menu ? menuTitles.get(command.menu) || '' : (menuId === null ? '' : menuTitles.get(menuId) || '');
+        const label = command.title || command.id;
+        const description = command.description || menuTitle || '';
+        items.push({
+          type: 'command',
+          label,
+          subtitle: description,
+          meta: shortcut,
+          searchText: `${label} ${command.id} ${description} ${(menuTitle || '')}`.toLowerCase(),
+          weight: TYPE_CONFIG.command.weight,
+          commandId: command.id,
+          disabled: command.enabled === false,
+        });
+      }
+    };
+    for (const menu of menus) {
+      const commands = this.registry.getCommands?.(menu.id) ?? [];
+      appendCommands(commands, menu.id);
+    }
+    const standalone = this.registry.getCommands?.(null) ?? [];
+    appendCommands(standalone, null);
+    return items;
+  }
+
+  _collectNodes() {
+    if (!this.explorer?.getAllNodes) return [];
+    const nodes = this.explorer.getAllNodes();
+    const items = [];
+    for (const node of nodes) {
+      if (!node) continue;
+      const label = node.Name ?? node.ClassName ?? 'Instance';
+      const path = buildNodePath(node);
+      const className = node.ClassName ?? '';
+      items.push({
+        type: 'node',
+        label,
+        subtitle: path,
+        meta: className,
+        searchText: `${label} ${className} ${path}`.toLowerCase(),
+        weight: TYPE_CONFIG.node.weight,
+        node,
+      });
+    }
+    return items;
+  }
+
+  _collectAssets() {
+    if (!this.assets?.getAssetEntries) return [];
+    const entries = this.assets.getAssetEntries();
+    const items = [];
+    for (const asset of entries) {
+      if (!asset) continue;
+      const label = normalizeAssetName(asset);
+      const type = asset.type || '';
+      const path = asset.logicalPath || '';
+      items.push({
+        type: 'asset',
+        label,
+        subtitle: path,
+        meta: type ? type.charAt(0).toUpperCase() + type.slice(1) : '',
+        searchText: `${label} ${type} ${path}`.toLowerCase(),
+        weight: TYPE_CONFIG.asset.weight,
+        asset,
+      });
+    }
+    return items;
+  }
+
+  _filter() {
+    const query = this.query.toLowerCase();
+    let matches = [];
+    if (!query) {
+      matches = [...this.items].sort((a, b) => {
+        if (b.weight === a.weight) {
+          return a.label.localeCompare(b.label);
+        }
+        return b.weight - a.weight;
+      });
+    } else {
+      const scored = [];
+      for (const item of this.items) {
+        const score = computeFuzzyScore(query, item.searchText ?? item.label ?? '');
+        if (score === null) continue;
+        scored.push({ item, score: score + (item.weight ?? 0) });
+      }
+      scored.sort((a, b) => {
+        if (b.score === a.score) {
+          return a.item.label.localeCompare(b.item.label);
+        }
+        return b.score - a.score;
+      });
+      matches = scored.map(entry => entry.item);
+    }
+    const limit = 60;
+    this.visibleItems = matches.slice(0, limit);
+    if (this.activeIndex >= this.visibleItems.length) {
+      this.activeIndex = Math.max(0, this.visibleItems.length - 1);
+    }
+    this._renderResults();
+    this._highlightActive();
+  }
+
+  _renderResults() {
+    this.results.textContent = '';
+    if (!this.visibleItems.length) {
+      this.results.hidden = true;
+      this.empty.hidden = false;
+      return;
+    }
+    this.results.hidden = false;
+    this.empty.hidden = true;
+
+    let index = 0;
+    let lastType = null;
+    for (const item of this.visibleItems) {
+      if (item.type !== lastType) {
+        lastType = item.type;
+        const header = document.createElement('div');
+        header.className = 'command-palette__section';
+        header.textContent = TYPE_CONFIG[item.type]?.label ?? item.type;
+        this.results.appendChild(header);
+      }
+      const row = document.createElement('div');
+      row.className = 'command-palette__item';
+      row.dataset.index = String(index);
+      if (item.disabled) {
+        row.classList.add('is-disabled');
+      }
+
+      const textWrap = document.createElement('div');
+      textWrap.className = 'command-palette__item-text';
+      const label = document.createElement('div');
+      label.className = 'command-palette__item-label';
+      label.innerHTML = highlightMatch(item.label ?? '', this.query);
+      textWrap.appendChild(label);
+      if (item.subtitle) {
+        const subtitle = document.createElement('div');
+        subtitle.className = 'command-palette__item-subtitle';
+        subtitle.innerHTML = highlightMatch(item.subtitle, this.query);
+        textWrap.appendChild(subtitle);
+      }
+
+      const meta = document.createElement('div');
+      meta.className = 'command-palette__item-meta';
+      meta.textContent = item.meta ?? '';
+
+      row.append(textWrap, meta);
+      this.results.appendChild(row);
+      index += 1;
+    }
+  }
+
+  _highlightActive() {
+    const rows = this.results.querySelectorAll('.command-palette__item');
+    rows.forEach(row => {
+      const index = Number(row.dataset.index ?? '-1');
+      row.classList.toggle('is-active', index === this.activeIndex);
+    });
+    const activeRow = this.results.querySelector(`.command-palette__item[data-index="${this.activeIndex}"]`);
+    if (activeRow) {
+      activeRow.scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  _moveSelection(direction) {
+    if (!this.visibleItems.length) return;
+    if (direction === 'start') {
+      this.activeIndex = 0;
+    } else if (direction === 'end') {
+      this.activeIndex = this.visibleItems.length - 1;
+    } else if (typeof direction === 'number' && Number.isFinite(direction)) {
+      const next = this.activeIndex + direction;
+      if (next < 0) {
+        this.activeIndex = this.visibleItems.length - 1;
+      } else if (next >= this.visibleItems.length) {
+        this.activeIndex = 0;
+      } else {
+        this.activeIndex = next;
+      }
+    }
+    this._highlightActive();
+  }
+
+  _activate({ openContextMenu = false } = {}) {
+    if (!this.visibleItems.length) return;
+    const item = this.visibleItems[this.activeIndex];
+    if (!item) return;
+    if (item.disabled) {
+      return;
+    }
+    this.close();
+    if (item.type === 'command') {
+      this.registry?.execute?.(item.commandId, { source: 'palette' });
+    } else if (item.type === 'node') {
+      if (this.shell?.activatePane) {
+        this.shell.activatePane('explorer');
+      }
+      this.explorer?.focusNode?.(item.node, { openContextMenu });
+    } else if (item.type === 'asset') {
+      if (this.shell?.activatePane) {
+        this.shell.activatePane('assets');
+      }
+      this.assets?.focusAsset?.(item.asset, { openContextMenu });
+    }
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="/editor/ui/statusbar.css" />
   <link rel="stylesheet" href="/editor/ui/toast.css" />
   <link rel="stylesheet" href="/editor/ui/progress.css" />
+  <link rel="stylesheet" href="/editor/ui/palette.css" />
   <link rel="stylesheet" href="/editor/panes/explorer.css" />
   <link rel="stylesheet" href="/editor/panes/properties.css" />
   <link rel="stylesheet" href="/editor/panes/assets.css" />


### PR DESCRIPTION
## Summary
- add a command palette overlay with fuzzy search across commands, scene nodes, and assets and wire it to Ctrl/Cmd+K
- expose explorer and assets helpers so palette results can focus selections or open context menu actions in their panes
- style the palette overlay and load its stylesheet in the editor shell

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4d61bc7fc832c9d9ef8d933c5b851