### PR TITLE
Fix shadow PCF sampling for depth array maps

### DIFF
--- a/engine/render/materials/shadow.wgsl
+++ b/engine/render/materials/shadow.wgsl
@@ -1,22 +1,26 @@
 const SHADOW_TAP_COUNT : f32 = 9.0;
 
-fn sampleShadow3x3(
+fn pcf3x3_array(
   shadowMap : texture_depth_2d_array,
   shadowSampler : sampler_comparison,
-  coords : vec3<f32>,
-  depth : f32
+  uv : vec2<f32>,
+  layer : i32,
+  compareDepth : f32,
+  texelSize : vec2<f32>
 ) -> f32 {
-  var visibility = 0.0;
-  visibility += textureSampleCompare(shadowMap, shadowSampler, coords, depth, vec2<i32>(-1, -1));
-  visibility += textureSampleCompare(shadowMap, shadowSampler, coords, depth, vec2<i32>(0, -1));
-  visibility += textureSampleCompare(shadowMap, shadowSampler, coords, depth, vec2<i32>(1, -1));
-  visibility += textureSampleCompare(shadowMap, shadowSampler, coords, depth, vec2<i32>(-1, 0));
-  visibility += textureSampleCompare(shadowMap, shadowSampler, coords, depth, vec2<i32>(0, 0));
-  visibility += textureSampleCompare(shadowMap, shadowSampler, coords, depth, vec2<i32>(1, 0));
-  visibility += textureSampleCompare(shadowMap, shadowSampler, coords, depth, vec2<i32>(-1, 1));
-  visibility += textureSampleCompare(shadowMap, shadowSampler, coords, depth, vec2<i32>(0, 1));
-  visibility += textureSampleCompare(shadowMap, shadowSampler, coords, depth, vec2<i32>(1, 1));
-  return visibility / SHADOW_TAP_COUNT;
+  let safeTexel = max(texelSize, vec2<f32>(0.0));
+  let minUv = safeTexel;
+  let maxUv = vec2<f32>(1.0) - safeTexel;
+  let baseUv = clamp(uv, minUv, maxUv);
+
+  var sum = 0.0;
+  for (var y : i32 = -1; y <= 1; y = y + 1) {
+    for (var x : i32 = -1; x <= 1; x = x + 1) {
+      let offset = vec2<i32>(x, y);
+      sum = sum + textureSampleCompare(shadowMap, shadowSampler, baseUv, layer, compareDepth, offset);
+    }
+  }
+  return sum / SHADOW_TAP_COUNT;
 }
 
 fn shadowInsideFrustum(uv : vec2<f32>, depth : f32) -> bool {


### PR DESCRIPTION
## Summary
- update the WGSL PCF helper to sample texture_depth_2d_array layers with comparison offsets
- remap cascade depth to the [0,1] range and apply bias before the comparison
- feed the cascade index and texel size into the shadow lookup used by the PBR shader

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4d900763c832c9ecd3d3c9fe55415