### PR TITLE
Fix default PBR resources and shader helper

### DIFF
--- a/engine/render/materials/defaults.js
+++ b/engine/render/materials/defaults.js
@@ -1,0 +1,62 @@
+let _cache = null;
+
+function makeTex(device, format, dataUint8, usage = GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST) {
+  const texture = device.createTexture({
+    size: [1, 1, 1],
+    format,
+    usage,
+    dimension: '2d',
+  });
+  device.queue.writeTexture(
+    { texture },
+    dataUint8,
+    { bytesPerRow: dataUint8.byteLength, rowsPerImage: 1 },
+    { width: 1, height: 1, depthOrArrayLayers: 1 },
+  );
+  return texture.createView();
+}
+
+export function ensureDefaultMaterialResources(device) {
+  if (_cache && _cache.device === device) {
+    return _cache;
+  }
+
+  _cache = null;
+
+  const whiteSRGB = new Uint8Array([255, 255, 255, 255]);
+  const blackSRGB = new Uint8Array([0, 0, 0, 255]);
+  const normalLin = new Uint8Array([128, 128, 255, 255]);
+  const aoLin = new Uint8Array([255, 255, 255, 255]);
+  const mrLin = new Uint8Array([0, 255, 255, 255]);
+
+  const baseColorView = makeTex(device, 'rgba8unorm-srgb', whiteSRGB);
+  const emissiveView = makeTex(device, 'rgba8unorm-srgb', blackSRGB);
+  const normalView = makeTex(device, 'rgba8unorm', normalLin);
+  const occlusionView = makeTex(device, 'rgba8unorm', aoLin);
+  const metallicRoughView = makeTex(device, 'rgba8unorm', mrLin);
+
+  const linearSampler = device.createSampler({
+    minFilter: 'linear',
+    magFilter: 'linear',
+    mipmapFilter: 'linear',
+  });
+  const repeatSampler = device.createSampler({
+    addressModeU: 'repeat',
+    addressModeV: 'repeat',
+    minFilter: 'linear',
+    magFilter: 'linear',
+    mipmapFilter: 'linear',
+  });
+
+  _cache = {
+    device,
+    baseColorView,
+    emissiveView,
+    normalView,
+    occlusionView,
+    metallicRoughView,
+    linearSampler,
+    repeatSampler,
+  };
+  return _cache;
+}

--- a/engine/render/materials/material.js
+++ b/engine/render/materials/material.js
@@ -40,17 +40,29 @@ export class StandardPBRMaterial {
   }
 
   update(params = {}) {
+    if (Object.prototype.hasOwnProperty.call(params, 'baseColorFactor')) {
+      this.color = toVec4Color(params.baseColorFactor);
+    }
     if (Object.prototype.hasOwnProperty.call(params, 'color')) {
       this.color = toVec4Color(params.color);
     }
-    if (Object.prototype.hasOwnProperty.call(params, 'roughness') && typeof params.roughness === 'number') {
+    if (Object.prototype.hasOwnProperty.call(params, 'roughnessFactor') && typeof params.roughnessFactor === 'number') {
+      this.roughness = params.roughnessFactor;
+    } else if (Object.prototype.hasOwnProperty.call(params, 'roughness') && typeof params.roughness === 'number') {
       this.roughness = params.roughness;
     }
-    if (Object.prototype.hasOwnProperty.call(params, 'metalness') && typeof params.metalness === 'number') {
+    if (Object.prototype.hasOwnProperty.call(params, 'metallicFactor') && typeof params.metallicFactor === 'number') {
+      this.metalness = params.metallicFactor;
+    } else if (Object.prototype.hasOwnProperty.call(params, 'metalness') && typeof params.metalness === 'number') {
       this.metalness = params.metalness;
     }
     if (Object.prototype.hasOwnProperty.call(params, 'emissive')) {
       const arr = Array.from(params.emissive ?? DEFAULT_EMISSIVE);
+      while (arr.length < 3) arr.push(0);
+      this.emissive = new Float32Array([...arr.slice(0, 3), 0]);
+    }
+    if (Object.prototype.hasOwnProperty.call(params, 'emissiveFactor')) {
+      const arr = Array.from(params.emissiveFactor ?? DEFAULT_EMISSIVE);
       while (arr.length < 3) arr.push(0);
       this.emissive = new Float32Array([...arr.slice(0, 3), 0]);
     }
@@ -61,8 +73,14 @@ export class StandardPBRMaterial {
     if (Object.prototype.hasOwnProperty.call(params, 'albedoTexture')) {
       this.maps.albedo.texture = params.albedoTexture;
     }
+    if (Object.prototype.hasOwnProperty.call(params, 'baseColorTexture')) {
+      this.maps.albedo.texture = params.baseColorTexture;
+    }
     if (Object.prototype.hasOwnProperty.call(params, 'albedoSampler')) {
       this.maps.albedo.sampler = params.albedoSampler;
+    }
+    if (Object.prototype.hasOwnProperty.call(params, 'baseColorSampler')) {
+      this.maps.albedo.sampler = params.baseColorSampler;
     }
     if (Object.prototype.hasOwnProperty.call(params, 'metallicRoughnessTexture')) {
       this.maps.metallicRoughness.texture = params.metallicRoughnessTexture;

--- a/engine/render/materials/pbrStandard.wgsl
+++ b/engine/render/materials/pbrStandard.wgsl
@@ -81,7 +81,6 @@ fn vs(input : VertexInput) -> VertexOutput {
   return output;
 }
 
-@fragment
 fn fresnelSchlick(cosTheta : f32, F0 : vec3<f32>) -> vec3<f32> {
   let ct = clamp(cosTheta, 0.0, 1.0);
   return F0 + (vec3<f32>(1.0) - F0) * pow(1.0 - ct, 5.0);


### PR DESCRIPTION
## Summary
- add cached fallback PBR textures and samplers so materials can bind even when maps are missing
- normalize StandardPBRMaterial updates to accept glTF-style factor parameters used by the editor and importer
- remove the stray entry-point attribute from the Fresnel helper in the PBR shader

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4f627938c832cb9316f76e1701264